### PR TITLE
Fix Visual Studio Debugging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,11 +9,15 @@ add_executable (lt "src/Main.cpp")
 phx_configure_output_dir (lt)
 phx_configure_target_properties (lt)
 
-target_compile_definitions (lt PRIVATE DEBUG=0)
+target_compile_definitions (lt PRIVATE DEBUG=$<CONFIG:DEBUG>)
 target_link_libraries (lt phx)
 
 set_target_properties (lt PROPERTIES
   OUTPUT_NAME_DEBUG "lt${ARCH}d"
-  OUTPUT_NAME_RELEASE "lt${ARCH}r"
+  OUTPUT_NAME_RELEASE "lt${ARCH}"
   OUTPUT_NAME_RELWITHDEBINFO "lt${ARCH}"
-  OUTPUT_NAME_MINSIZEREL "lt${ARCH}rm")
+  OUTPUT_NAME_MINSIZEREL "lt${ARCH}")
+
+if (WIN32)
+  set_property(TARGET lt PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+endif ()

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ python configure.py run
 
 # Debugging in Visual Studio
 
-First, make sure that the CMake project is configured by running the steps above up to `python configre.py`.
+First, make sure that the CMake project is configured by running the steps above up to `python configure.py`.
 
-Next, open the Visual Studio solution by navigating to `build/LTheory.sln` and opening it. Once the project has loaded, right click the `lt` project in the Solution Explorer, then select "Set as Startup Project". To select a Lua script to run, right click the `lt` project, then select Properties, then Debugging, then change the value in "Command Line Arguments" to the desired Lua script. Leave this blank to launch the default Lua script (`LTheory`).
+Next, open the Visual Studio solution by navigating to `build/LTheory.sln` and opening it. Once the project has loaded, right click the `lt` project in the Solution Explorer, then select "Set as Startup Project".
+
+To select a Lua script to run, right click the `lt` project, then select Properties, then Debugging, then change the value in "Command Line Arguments" to the desired Lua script. Leave this blank to launch the default Lua script (`LTheory`).

--- a/README.md
+++ b/README.md
@@ -75,3 +75,9 @@ python configure.py
 python configure.py build
 python configure.py run
 ```
+
+# Debugging in Visual Studio
+
+First, make sure that the CMake project is configured by running the steps above up to `python configre.py`.
+
+Next, open the Visual Studio solution by navigating to `build/LTheory.sln` and opening it. Once the project has loaded, right click the `lt` project in the Solution Explorer, then select "Set as Startup Project". To select a Lua script to run, right click the `lt` project, then select Properties, then Debugging, then change the value in "Command Line Arguments" to the desired Lua script. Leave this blank to launch the default Lua script (`LTheory`).

--- a/libphx/CMakeLists.txt
+++ b/libphx/CMakeLists.txt
@@ -30,9 +30,9 @@ target_link_directories (phx PUBLIC "${ext_SOURCE_DIR}/lib/${PLATARCH}")
 set_target_properties (phx PROPERTIES
   PREFIX "lib"
   OUTPUT_NAME_DEBUG "phx${ARCH}d"
-  OUTPUT_NAME_RELEASE "phx${ARCH}r"
+  OUTPUT_NAME_RELEASE "phx${ARCH}"
   OUTPUT_NAME_RELWITHDEBINFO "phx${ARCH}"
-  OUTPUT_NAME_MINSIZEREL "phx${ARCH}rm")
+  OUTPUT_NAME_MINSIZEREL "phx${ARCH}")
 
 # ------------------------------------------------------------------------------
 

--- a/libphx/src/Shader.cpp
+++ b/libphx/src/Shader.cpp
@@ -186,8 +186,8 @@ Shader* Shader_Create (cstr vs, cstr fs) {
   Shader* self = MemNew(Shader);
   RefCounted_Init(self);
   ArrayList_Init(self->vars);
-  vs = GLSL_Preprocess(StrDup(vs), self);
-  fs = GLSL_Preprocess(StrDup(fs), self);
+  vs = GLSL_Preprocess(StrReplace(vs, "\r\n", "\n"), self);
+  fs = GLSL_Preprocess(StrReplace(fs, "\r\n", "\n"), self);
   self->vs = CreateGLShader(vs, GL_VERTEX_SHADER);
   self->fs = CreateGLShader(fs, GL_FRAGMENT_SHADER);
   self->program = CreateGLProgram(self->vs, self->fs);

--- a/script/App/GenTex2D.lua
+++ b/script/App/GenTex2D.lua
@@ -3,7 +3,7 @@ local GenTex2D = Application()
 local kTexSize = 1024
 local rng = RNG.FromTime()
 
-local vs = Cache.File('../shared/res/shader/vertex/ui.glsl')
+local vs = Resource.LoadCstr(ResourceType.Shader, 'vertex/ui')
 
 -- Main generating fragment shader
 local fs = [[


### PR DESCRIPTION
This PR makes a few changes:

* Fix the lt64/libphx64 suffixes when building under release/relwithdebinfo/minsizerel. There should only be a d suffix with the debug build.
* Ensure that the debugging working directory for Visual Studio is set correctly by CMake.
* Add some instructions on how to debug with VS.
* Fix a crash in `Shader_Create`
* Fix a resource loading issue in `GenTex2D.lua`