### PR TITLE
Basic sound fader support

### DIFF
--- a/libphx/include/Sound.h
+++ b/libphx/include/Sound.h
@@ -35,6 +35,7 @@ PHX_API cstr    Sound_GetName                (Sound*);
 PHX_API cstr    Sound_GetPath                (Sound*);
 PHX_API bool    Sound_IsFinished             (Sound*);
 PHX_API bool    Sound_IsPlaying              (Sound*);
+PHX_API bool    Sound_IsAudible              (Sound*);
 
 PHX_API void    Sound_Attach3DPos            (Sound*, Vec3f const* pos, Vec3f const* vel);
 PHX_API void    Sound_Set3DLevel             (Sound*, float);
@@ -44,6 +45,8 @@ PHX_API void    Sound_SetPan                 (Sound*, float);
 PHX_API void    Sound_SetPitch               (Sound*, float);
 PHX_API void    Sound_SetPlayPos             (Sound*, float);
 PHX_API void    Sound_SetVolume              (Sound*, float);
+PHX_API void    Sound_FadeIn                 (Sound*, float);
+PHX_API void    Sound_FadeOut                (Sound*, float);
 
 /* --- Convenience API ------------------------------------------------------ */
 

--- a/libphx/script/ffi/Sound.lua
+++ b/libphx/script/ffi/Sound.lua
@@ -21,6 +21,7 @@ do -- C Definitions
     cstr   Sound_GetPath               (Sound*);
     bool   Sound_IsFinished            (Sound*);
     bool   Sound_IsPlaying             (Sound*);
+    bool   Sound_IsAudible             (Sound*);
     void   Sound_Attach3DPos           (Sound*, Vec3f const* pos, Vec3f const* vel);
     void   Sound_Set3DLevel            (Sound*, float);
     void   Sound_Set3DPos              (Sound*, Vec3f const* pos, Vec3f const* vel);
@@ -29,6 +30,8 @@ do -- C Definitions
     void   Sound_SetPitch              (Sound*, float);
     void   Sound_SetPlayPos            (Sound*, float);
     void   Sound_SetVolume             (Sound*, float);
+    void   Sound_FadeIn                (Sound*, float);
+    void   Sound_FadeOut               (Sound*, float);
     Sound* Sound_LoadPlay              (cstr name, bool isLooped, bool is3D);
     Sound* Sound_LoadPlayAttached      (cstr name, bool isLooped, bool is3D, Vec3f const* pos, Vec3f const* vel);
     void   Sound_LoadPlayFree          (cstr name, bool isLooped, bool is3D);
@@ -58,6 +61,7 @@ do -- Global Symbol Table
     GetPath               = libphx.Sound_GetPath,
     IsFinished            = libphx.Sound_IsFinished,
     IsPlaying             = libphx.Sound_IsPlaying,
+    IsAudible             = libphx.Sound_IsAudible,
     Attach3DPos           = libphx.Sound_Attach3DPos,
     Set3DLevel            = libphx.Sound_Set3DLevel,
     Set3DPos              = libphx.Sound_Set3DPos,
@@ -66,6 +70,8 @@ do -- Global Symbol Table
     SetPitch              = libphx.Sound_SetPitch,
     SetPlayPos            = libphx.Sound_SetPlayPos,
     SetVolume             = libphx.Sound_SetVolume,
+    FadeIn                = libphx.Sound_FadeIn,
+    FadeOut               = libphx.Sound_FadeOut,
     LoadPlay              = libphx.Sound_LoadPlay,
     LoadPlayAttached      = libphx.Sound_LoadPlayAttached,
     LoadPlayFree          = libphx.Sound_LoadPlayFree,
@@ -99,6 +105,7 @@ do -- Metatype for class instances
       getPath               = libphx.Sound_GetPath,
       isFinished            = libphx.Sound_IsFinished,
       isPlaying             = libphx.Sound_IsPlaying,
+      isAudible             = libphx.Sound_IsAudible,
       attach3DPos           = libphx.Sound_Attach3DPos,
       set3DLevel            = libphx.Sound_Set3DLevel,
       set3DPos              = libphx.Sound_Set3DPos,
@@ -107,6 +114,8 @@ do -- Metatype for class instances
       setPitch              = libphx.Sound_SetPitch,
       setPlayPos            = libphx.Sound_SetPlayPos,
       setVolume             = libphx.Sound_SetVolume,
+      fadeIn                = libphx.Sound_FadeIn,
+      fadeOut               = libphx.Sound_FadeOut,
       clonePlay             = libphx.Sound_ClonePlay,
       clonePlayAttached     = libphx.Sound_ClonePlayAttached,
       clonePlayFree         = libphx.Sound_ClonePlayFree,

--- a/libphx/src/Sound.cpp
+++ b/libphx/src/Sound.cpp
@@ -190,6 +190,13 @@ bool Sound_IsPlaying (Sound* self) {
   return self->state == SoundState_Playing;
 }
 
+bool Sound_IsAudible (Sound* self) {
+  Sound_EnsureState(self);
+  float audibility = 0.0f;
+  FMODCALL(FMOD_Channel_GetAudibility(self->handle, &audibility));
+  return audibility > 0.0f;
+}
+
 void Sound_Attach3DPos (Sound* self, Vec3f const* pos, Vec3f const* vel) {
   //EnsureState happens in Set3DPos already
   Sound_Set3DPos(self, pos, vel);
@@ -235,6 +242,58 @@ void Sound_SetPlayPos (Sound* self, float seconds) {
 void Sound_SetVolume (Sound* self, float volume) {
   Sound_EnsureState(self);
   FMODCALL(FMOD_Channel_SetVolume(self->handle, volume));
+}
+
+void Sound_FadeIn (Sound* self, float seconds) {
+  Sound_EnsureState(self);
+  Assert(seconds >= 0.0f);
+
+  if (Sound_IsPlaying(self) == false) Sound_Play(self);
+  
+  // Already fading in/out?
+  unsigned int numpoints = 0;
+  FMODCALL(FMOD_Channel_GetFadePoints(self->handle, &numpoints, 0, 0));
+  if (numpoints > 0) return;
+
+  int rate = 0;
+	FMODCALL(FMOD_System_GetSoftwareFormat((FMOD_SYSTEM*)Audio_GetHandle(), &rate, 0, 0));
+  unsigned long long fadeTime = unsigned long long(rate * seconds);
+
+  float volume = 1.0f;
+  FMODCALL(FMOD_Channel_GetVolume(self->handle, &volume));
+
+  unsigned long long dspClock = 0u;
+  FMODCALL(FMOD_Channel_GetDSPClock(self->handle, nullptr, &dspClock));
+  
+  FMODCALL(FMOD_Channel_SetDelay(self->handle, dspClock, 0, false));
+
+  FMODCALL(FMOD_Channel_AddFadePoint(self->handle, dspClock, 0.0f));
+  FMODCALL(FMOD_Channel_AddFadePoint(self->handle, dspClock + fadeTime, volume));
+}
+
+void Sound_FadeOut (Sound* self, float seconds) {
+  Sound_EnsureState(self);
+  Assert(seconds >= 0.0f);
+
+  // Already fading in/out?
+  unsigned int numpoints = 0;
+  FMODCALL(FMOD_Channel_GetFadePoints(self->handle, &numpoints, 0, 0));
+  if (numpoints > 0) return;
+
+  int rate = 0;
+	FMODCALL(FMOD_System_GetSoftwareFormat((FMOD_SYSTEM*)Audio_GetHandle(), &rate, 0, 0));
+  unsigned long long fadeTime = unsigned long long(rate * seconds);
+  
+  float volume = 1.0f;
+  FMODCALL(FMOD_Channel_GetVolume(self->handle, &volume));
+
+  unsigned long long dspClock = 0u;
+  FMODCALL(FMOD_Channel_GetDSPClock(self->handle, nullptr, &dspClock));
+
+  FMODCALL(FMOD_Channel_AddFadePoint(self->handle, dspClock, volume));
+  FMODCALL(FMOD_Channel_AddFadePoint(self->handle, dspClock + fadeTime, 0.0f));
+
+  FMODCALL(FMOD_Channel_SetDelay(self->handle, 0, dspClock + fadeTime, false));
 }
 
 Sound* Sound_LoadPlay (cstr name, bool isLooped, bool is3D) {

--- a/libphx/src/Sound.cpp
+++ b/libphx/src/Sound.cpp
@@ -257,7 +257,7 @@ void Sound_FadeIn (Sound* self, float seconds) {
 
   int rate = 0;
 	FMODCALL(FMOD_System_GetSoftwareFormat((FMOD_SYSTEM*)Audio_GetHandle(), &rate, 0, 0));
-  unsigned long long fadeTime = unsigned long long(rate * seconds);
+  unsigned long long fadeTime = (unsigned long long)(rate * seconds);
 
   float volume = 1.0f;
   FMODCALL(FMOD_Channel_GetVolume(self->handle, &volume));
@@ -282,7 +282,7 @@ void Sound_FadeOut (Sound* self, float seconds) {
 
   int rate = 0;
 	FMODCALL(FMOD_System_GetSoftwareFormat((FMOD_SYSTEM*)Audio_GetHandle(), &rate, 0, 0));
-  unsigned long long fadeTime = unsigned long long(rate * seconds);
+  unsigned long long fadeTime = (unsigned long long)(rate * seconds);
   
   float volume = 1.0f;
   FMODCALL(FMOD_Channel_GetVolume(self->handle, &volume));

--- a/script/States/App/FMODTest.lua
+++ b/script/States/App/FMODTest.lua
@@ -3,9 +3,14 @@ local Bindings = require('States.ApplicationBindings')
 
 local FMODTest = require('States.Application')
 
+local Music = {
+  MainTheme = './res/sound/system/ambiance/LTR_Surpassing_The_Limit_Redux_Ambient_Long_Fade',
+  AltTheme = './res/sound/system/ambiance/LTR_Parallax_Universe_loop'
+}
+
 local SFX = {
-  Gun  = 'blaster',
-  Hero = 'chewy',
+--  Gun  = 'blaster',
+--  Hero = 'chewy',
 }
 
 local kMoveSpeed = 100.0
@@ -19,12 +24,12 @@ function FMODTest:onInit ()
   Audio.Set3DSettings(1, 10, 2);
 
   self.emitters = {
-    { file = 'cantina', image = 'image/cantinaband', x = 128, y = 100 },
-    { file = 'Imperial_March', image = 'image/vader', x = 256, y = 600 },
+  --  { file = 'cantina', image = 'image/cantinaband', x = 128, y = 100 },
+  --  { file = 'Imperial_March', image = 'image/vader', x = 256, y = 600 },
   }
 
   self.ambiances = {
-    '900years',
+--[[     '900years',
     'breath',
     'chewy',
     'chosenone',
@@ -36,7 +41,7 @@ function FMODTest:onInit ()
     'thybidding',
     'traintheboy',
     'yesmaster',
-    'yodalaugh',
+    'yodalaugh', ]]
   }
 
   self.rng = RNG.FromTime()
@@ -47,7 +52,13 @@ function FMODTest:onInit ()
     end
   end
 
-  Sound.Load('cantina', true, true)
+--  Sound.Load('cantina', true, true)
+
+  self.musicToggle = 0
+  self.music = {}
+  self.music[0] = Sound.Load(Music.MainTheme, false, false)
+  self.music[1] = Sound.Load(Music.AltTheme, false, false)
+  self.music[self.musicToggle]:play()
 
   for i = 1, #self.emitters do
     local e = self.emitters[i]
@@ -68,22 +79,22 @@ function FMODTest:onInit ()
   self.ambianceTimer = 1.0 + self.rng:getExp()
   self.particles = {}
 
-  self.onKeyDown = {
-    [Key.S] = function () self.vel.z = self.vel.z + kMoveSpeed * self.dt end,
-    [Key.W] = function () self.vel.z = self.vel.z - kMoveSpeed * self.dt end,
-    [Key.D] = function () self.vel.x = self.vel.x + kMoveSpeed * self.dt end,
-    [Key.A] = function () self.vel.x = self.vel.x - kMoveSpeed * self.dt end,
-  }
+  -- self.onKeyDown = {
+  --   [Key.S] = function () self.vel.z = self.vel.z + kMoveSpeed * self.dt end,
+  --   [Key.W] = function () self.vel.z = self.vel.z - kMoveSpeed * self.dt end,
+  --   [Key.D] = function () self.vel.x = self.vel.x + kMoveSpeed * self.dt end,
+  --   [Key.A] = function () self.vel.x = self.vel.x - kMoveSpeed * self.dt end,
+  -- }
 
-  self.onKeyPress = {
-    [Key.N1]    = function () Audio.Prepare(Audio.Load(SFX.Gun, true), true, false):play() end,
-    [Key.N2]    = function () Audio.Prepare(Audio.Load(SFX.Hero, true), false, false):play() end,
-    [Key.Left]  = function () self.pos = Vec3f( 10,  0,   0) end,
-    [Key.Right] = function () self.pos = Vec3f(-10,  0,   0) end,
-    [Key.Up]    = function () self.pos = Vec3f(  0,  0, -10) end,
-    [Key.Down]  = function () self.pos = Vec3f(  0,  0,  10) end,
-    [Key.Space] = function () self.pos = Vec3f(  0,  2,   0) end,
-  }
+  -- self.onKeyPress = {
+  --   [Key.N1]    = function () Audio.Prepare(Audio.Load(SFX.Gun, true), true, false):play() end,
+  --   [Key.N2]    = function () Audio.Prepare(Audio.Load(SFX.Hero, true), false, false):play() end,
+  --   [Key.Left]  = function () self.pos = Vec3f( 10,  0,   0) end,
+  --   [Key.Right] = function () self.pos = Vec3f(-10,  0,   0) end,
+  --   [Key.Up]    = function () self.pos = Vec3f(  0,  0, -10) end,
+  --   [Key.Down]  = function () self.pos = Vec3f(  0,  0,  10) end,
+  --   [Key.Space] = function () self.pos = Vec3f(  0,  2,   0) end,
+  -- }
 end
 
 function FMODTest:onInput ()
@@ -91,30 +102,38 @@ function FMODTest:onInput ()
     self:quit()
   end
 
+  if Input.GetPressed(Button.Mouse.Left) then
+    -- Fade out currently playing music
+    self.music[self.musicToggle]:fadeOut(5.0)
+    -- Fade in alternate music
+    self.musicToggle = (self.musicToggle + 1) % 2
+    self.music[self.musicToggle]:fadeIn(5.0)
+  end
+
   if Input.GetDown(Button.Mouse.Left) then
-    if TimeStamp.GetElapsed(self.lastFireTime) > 0.12 then
-      self.lastFireTime = self.lastUpdate
-      local sound = Sound.Load(SFX.Gun, false, true)
-      sound:setFreeOnFinish(true)
-      sound:set3DPos(Vec3f(0, 0, 0), Vec3f(0, 0, 0))
-      sound:setVolume(Math.Lerp(0.2, 0.6, self.rng:getUniform() ^ 2.0))
-      sound:play()
-    end
+    -- if TimeStamp.GetElapsed(self.lastFireTime) > 0.12 then
+    --   self.lastFireTime = self.lastUpdate
+    --   local sound = Sound.Load(SFX.Gun, false, true)
+    --   sound:setFreeOnFinish(true)
+    --   sound:set3DPos(Vec3f(0, 0, 0), Vec3f(0, 0, 0))
+    --   sound:setVolume(Math.Lerp(0.2, 0.6, self.rng:getUniform() ^ 2.0))
+    --   sound:play()
+    -- end
   end
 
   if Input.GetDown(Button.Mouse.Right) then
-    local is = Input.GetState()
+    local is = Input.GetMousePosition()
     self.pos.x = is.mousePosition.x
     self.pos.z = is.mousePosition.y
   end
 
-  for k, v in pairs(self.onKeyDown) do
-    if Input.GetDown(k) then v() end
-  end
+  -- for k, v in pairs(self.onKeyDown) do
+  --   if Input.GetDown(k) then v() end
+  -- end
 
-  for k, v in pairs(self.onKeyPress) do
-    if Input.GetPressed(k) then v() end
-  end
+  -- for k, v in pairs(self.onKeyPress) do
+  --   if Input.GetPressed(k) then v() end
+  -- end
 end
 
 function FMODTest:onDraw ()
@@ -155,13 +174,13 @@ function FMODTest:onUpdate (dt)
     self.ambianceTimer = self.ambianceTimer - dt
     if self.ambianceTimer <= 0 then
       self.ambianceTimer = self.ambianceTimer + 0.25 * self.rng:getExp()
-      local sound = Sound.Load(self.rng:choose(self.ambiances), false, true)
+--      local sound = Sound.Load(self.rng:choose(self.ambiances), false, true)
       local dp = self.rng:getDir2():scale(100.0 * (1.0 + self.rng:getExp()))
-      sound:setFreeOnFinish(true)
-      sound:setPitch(Math.Clamp(1.0 + 0.1 * self.rng:getGaussian(), 0.6, 1.0 / 0.6))
-      sound:set3DPos(self.pos + Vec3f(dp.x, 0, dp.y), Vec3f(0, 0, 0))
-      sound:setVolume(0.5 + 0.5 * self.rng:getExp())
-      sound:play()
+      -- sound:setFreeOnFinish(true)
+      -- sound:setPitch(Math.Clamp(1.0 + 0.1 * self.rng:getGaussian(), 0.6, 1.0 / 0.6))
+      -- sound:set3DPos(self.pos + Vec3f(dp.x, 0, dp.y), Vec3f(0, 0, 0))
+      -- sound:setVolume(0.5 + 0.5 * self.rng:getExp())
+      -- sound:play()
       self.particles[#self.particles + 1] = { life = 5, x = self.pos.x + dp.x, y = self.pos.z + dp.y }
     end
   end

--- a/script/States/App/FMODTest.lua
+++ b/script/States/App/FMODTest.lua
@@ -56,8 +56,8 @@ function FMODTest:onInit ()
 
   self.musicToggle = 0
   self.music = {}
-  self.music[0] = Sound.Load(Music.MainTheme, false, false)
-  self.music[1] = Sound.Load(Music.AltTheme, false, false)
+  self.music[0] = Sound.Load(Music.MainTheme, true, false)
+  self.music[1] = Sound.Load(Music.AltTheme, true, false)
   self.music[self.musicToggle]:play()
 
   for i = 1, #self.emitters do


### PR DESCRIPTION
Basic support for fading sound in & out - mainly to support switching between music soundtracks

- Sound_FadeIn(seconds)
- Sound_FadeOut(seconds)
- bool Sound_IsAudible()

Fade in can be used to start playing a sound.
A faded out sound is paused and will continue from that point when faded in (could use Rewind())
An in progress fade in/out is unaffected by these calls.
Use IsAudible() to check if a sound is paused or not. IsPlaying() means that the sound is active - almost always, and IsPaused() does not exist but would make a sound inactive. The audio subsystem will only update **active** sounds per frame

Pre-empted the addition of a second music file by @Flatfingers so that FMODTest.lua could test fading between songs. Use left mouse to start a 5 second crossfade (sounds horrible).