### PR TITLE
Fix shader crash when HUD targetter tries to draw direction arrow

### DIFF
--- a/res/shader/fragment/ui/triangle.glsl
+++ b/res/shader/fragment/ui/triangle.glsl
@@ -9,7 +9,7 @@ uniform vec4 color;
 const float kRadius = 0.5;
 
 void main() {
-  vec3 p = pos;
+  vec2 p = pos.xy;
   vec2 center = (p1 + p2 + p3) / 3.0;
   vec2 p1n = p1 + kRadius * normalize(center - p1);
   vec2 p2n = p2 + kRadius * normalize(center - p2);

--- a/script/Systems/Overlay/HUD.lua
+++ b/script/Systems/Overlay/HUD.lua
@@ -220,8 +220,7 @@ function HUD:drawLock (a)
       dir:inormalize()
       ss = center + dir:scale(r)
       local a = a * (1.0 - exp(-max(0.0, dist / (r + 16) - 1.0)))
---      UI.DrawEx.Arrow(ss, dir:scale(6), Color(1.0, 0.5, 0.1, a))
-      UI.DrawEx.Cross(ss.x, ss.y, 4, Color(1.0, 0.5, 0.1, a))
+      UI.DrawEx.Arrow(ss, dir:scale(6), Color(1.0, 0.5, 0.1, a))
     end
   end
 


### PR DESCRIPTION
UI triangle shaders are 2D, so swizzle vec3s to vec2s
Use triangle in HUD targetter