### PR TITLE
Add support for draggable/resizable game window [PHX REBUILD REQUIRED]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ ehthumbs.db
 ehthumbs_vista.db
 *.stackdump
 [Dd]esktop.ini
+*.code-workspace

--- a/libphx/include/Button.h
+++ b/libphx/include/Button.h
@@ -167,6 +167,8 @@ PHX_API const Button Button_Gamepad_Last;
 
 PHX_API const Button Button_System_First;
 PHX_API const Button Button_System_Exit;
+PHX_API const Button Button_System_Win_Enter;
+PHX_API const Button Button_System_Win_Leave;
 PHX_API const Button Button_System_Last;
 
 PHX_API const Button Button_Last;

--- a/libphx/script/ffi/Button.lua
+++ b/libphx/script/ffi/Button.lua
@@ -166,6 +166,8 @@ do -- C Definitions
     Button     Button_Gamepad_Last;
     Button     Button_System_First;
     Button     Button_System_Exit;
+    Button     Button_System_Win_Enter;
+    Button     Button_System_Win_Leave;
     Button     Button_System_Last;
     Button     Button_Last;
   ]]
@@ -338,9 +340,11 @@ do -- Global Symbol Table
       Last         = libphx.Button_Gamepad_Last,
     },
     System = {
-      First = libphx.Button_System_First,
-      Exit  = libphx.Button_System_Exit,
-      Last  = libphx.Button_System_Last,
+      First       = libphx.Button_System_First,
+      Exit        = libphx.Button_System_Exit,
+      WindowEnter = libphx.Button_System_Win_Enter,
+      WindowLeave = libphx.Button_System_Win_Leave,
+      Last        = libphx.Button_System_Last,
     },
     ToDeviceType = libphx.Button_ToDeviceType,
     ToString     = libphx.Button_ToString,

--- a/libphx/src/Button.cpp
+++ b/libphx/src/Button.cpp
@@ -167,7 +167,9 @@ const Button Button_Gamepad_Last         = Button_Gamepad_First + 20;
 
 const Button Button_System_First         = Button_Gamepad_Last + 1;
 const Button Button_System_Exit          = Button_System_First + 0;
-const Button Button_System_Last          = Button_System_First + 0;
+const Button Button_System_Win_Enter     = Button_System_First + 1;
+const Button Button_System_Win_Leave     = Button_System_First + 2;
+const Button Button_System_Last          = Button_System_First + 2;
 
 const Button Button_Last                 = Button_System_Last;
 
@@ -337,6 +339,8 @@ cstr Button_ToString (Button button) {
       case Button_Gamepad_RStickX:      return "Button_Gamepad_RStickX";
       case Button_Gamepad_RStickY:      return "Button_Gamepad_RStickY";
       case Button_System_Exit:          return "Button_System_Exit";
+      case Button_System_Win_Enter:     return "Button_System_Win_Enter";
+      case Button_System_Win_Leave:     return "Button_System_Win_Leave";
   }
 }
 
@@ -348,6 +352,8 @@ bool Button_IsAutoRelease (Button button) {
     case Button_Mouse_ScrollX:
     case Button_Mouse_ScrollY:
     case Button_System_Exit:
+    case Button_System_Win_Enter:
+    case Button_System_Win_Leave:
       return true;
   }
 }

--- a/libphx/src/Input.cpp
+++ b/libphx/src/Input.cpp
@@ -489,12 +489,28 @@ void Input_Update () {
         break;
 
         case SDL_WINDOWEVENT: {
-          if (sdl.window.event == SDL_WINDOWEVENT_FOCUS_GAINED)
-            SDL_CaptureMouse(SDL_TRUE);
+          if (sdl.window.event == SDL_WINDOWEVENT_ENTER) {
+            Device device = { DeviceType_Null, 0 };
 
-          /* TODO : Test button release on focus loss */
-          if (sdl.window.event == SDL_WINDOWEVENT_FOCUS_LOST) {
-            SDL_CaptureMouse(SDL_FALSE);
+            event.device = device;
+            event.button = Button_System_Win_Enter;
+            event.value  = 0.0f;
+            event.state  = State_Changed | State_Pressed | State_Down;
+            Input_SetButton(event);
+            Input_AppendEvent(event);
+          }
+
+          if (sdl.window.event == SDL_WINDOWEVENT_LEAVE) {
+            Device device = { DeviceType_Null, 0 };
+
+            event.device = device;
+            event.button = Button_System_Win_Leave;
+            event.value  = 0.0f;
+            event.state  = State_Changed | State_Pressed | State_Down;
+            Input_SetButton(event);
+            Input_AppendEvent(event);
+
+            /* TODO : Test button release on focus loss */
 
             /* OPTIMIZE : Do this without incurring the cost of the search and
              *            removes in SetButton */

--- a/script/States/Application.lua
+++ b/script/States/Application.lua
@@ -127,6 +127,10 @@ function Application:run ()
         end
       end
 
+      if Input.GetPressed(Button.System.WindowLeave) and Config.getGameMode() ~= 1 then
+        Config.game.gamePaused = true
+      end
+
       if Config.game.gamePaused then
         timeScale = 0.0
       else


### PR DESCRIPTION
This PR addresses Issue #36 only.

Changes:

- Add System window input events to detect mouse enter/leave
- Allow mouse inputs when leaving the window for drag/resize etc
- Auto-pause game when leaving the window

Observations:

- The existing window resize is only a crop.
- Whilst paused, mouse movement within the window still moves turrets
- Whilst paused, mouse-left-click still starts a fire sequence