### PR TITLE
Add HighDPI support for Windows using manifest file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@ add_executable (lt "src/Main.cpp")
 phx_configure_output_dir (lt)
 phx_configure_target_properties (lt)
 
+if (WIN32)
+  target_sources(lt PRIVATE "src/lt.manifest")
+endif ()
+
 target_compile_definitions (lt PRIVATE DEBUG=$<CONFIG:DEBUG>)
 target_link_libraries (lt phx)
 

--- a/libphx/src/Window.cpp
+++ b/libphx/src/Window.cpp
@@ -15,7 +15,7 @@ struct Window {
 
 Window* Window_Create (cstr title, int x, int y, int sx, int sy, WindowMode mode) {
   Window* self = MemNew(Window);
-  mode |= SDL_WINDOW_OPENGL;
+  mode |= (SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI);
   cstr titleWithBuild = StrAdd(title, " (libphx version " __DATE__ ")");
   self->handle = SDL_CreateWindow(titleWithBuild, x, y, sx, sy, mode);
   StrFree(titleWithBuild);

--- a/src/lt.manifest
+++ b/src/lt.manifest
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1"> 
+        <application> 
+            <!-- Windows 10 --> 
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+            <!-- Windows 8.1 -->
+            <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+            <!-- Windows Vista -->
+            <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/> 
+            <!-- Windows 7 -->
+            <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+            <!-- Windows 8 -->
+            <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+        </application> 
+    </compatibility>
+    <application xmlns="urn:schemas-microsoft-com:asm.v3">
+        <windowsSettings>
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+            <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+        </windowsSettings>
+    </application>
+</assembly>


### PR DESCRIPTION
Us a manifest file to make lt executable DPI aware on windows.

The SDL2 library does not support this feature still. Added DPI window mode to PHX engine anyway in case of future compatibility or Linux/MacOS support.