### PR TITLE
Settings / Energy Capacitor / Overcharge

### DIFF
--- a/script/Config/App.lua
+++ b/script/Config/App.lua
@@ -87,9 +87,9 @@ Config.gen = {
 
   nFields    = 20,
   nFieldSize = function (rng) return 200 * (rng:getExp() + 1.0) end,
-  nStations  = 0,
-  nPlanets   = 0,
   nAsteroids = 200, -- asteroids per asteroid field (smaller = less CPU hit)
+  nPlanets   = 0,
+  nStations  = 0,
   nBeltSize  = function (rng) return 0 end, -- asteroids per planetary belt
 
   nDustFlecks = 1024,
@@ -168,6 +168,7 @@ Config.game = {
   pulseSpeed             = 1e3, -- was 6e2
   pulseRange             = 1000,
   pulseSpread            = 0.01,
+  pulseCharge            = 2.0, -- default amount of capacitor charge used by each shot
   pulseColorBodyR        = 0.3,
   pulseColorBodyG        = 0.8,
   pulseColorBodyB        = 2.0,
@@ -244,7 +245,7 @@ Config.ui = {
   showTrackers     = true,
   controlBarHeight = 48,
   hudDisplayed     = 0,
-  SensorsDisplayed = true,
+  sensorsDisplayed = true,
   cursorSmooth     = "cursor/cursor1-small",
   cursorSimple     = "cursor/Simple_Cursor",
   cursor           = "cursor/Simple_Cursor",
@@ -280,6 +281,7 @@ Config.ui.color = {
   clientBackground  = Color(0.30, 0.30, 0.30, 0.0),
   meterBar          = Color(0.10, 0.60, 1.00, 0.7),
   meterBarDark      = Color(0.00, 0.30, 0.70, 0.1),
+  meterBarOver      = Color(1.00, 0.30, 0.00, 0.6),
   remainingBoost    = Color(1.00, 0.50, 0.00, 0.7),
   remainingEnergy   = Color(0.50, 0.00, 1.00, 0.7),
 

--- a/script/GameObjects/Actions/Attack.lua
+++ b/script/GameObjects/Actions/Attack.lua
@@ -53,8 +53,9 @@ function Attack:onUpdateActive (e, dt)
 end
 
 function Attack:onUpdatePassive (e, dt)
+  local distance = e:getDistance(self.target)
   local align = (self.target:getPos() - e:getPos()):normalize():dot(e:getForward())
-  if align < 0.25 then return end
+  if align < 0.25 or distance > Config.game.pulseRange then return end -- TODO: extend range check to other weapon type ranges
   local firing = Config.game.aiFire(dt, rng)
   for turret in e:iterSocketsByType(SocketType.Turret) do
     turret:aimAtTarget(self.target, self.target:getPos())

--- a/script/GameObjects/Components/Ship/Capacitor.lua
+++ b/script/GameObjects/Components/Ship/Capacitor.lua
@@ -39,6 +39,11 @@ function Entity:getChargeNormalized ()
   return self.charge / self.chargeMax
 end
 
+function Entity:getChargePercent ()
+  assert(self.health)
+  return 100.0 * self.charge / self.chargeMax
+end
+
 function Entity:hasCharge ()
   return self.charge ~= nil
 end

--- a/script/GameObjects/Components/Ship/Capacitor.lua
+++ b/script/GameObjects/Components/Ship/Capacitor.lua
@@ -40,7 +40,7 @@ function Entity:getChargeNormalized ()
 end
 
 function Entity:getChargePercent ()
-  assert(self.health)
+  assert(self.charge)
   return 100.0 * self.charge / self.chargeMax
 end
 

--- a/script/GameObjects/Entities/Ship/Turret.lua
+++ b/script/GameObjects/Entities/Ship/Turret.lua
@@ -93,7 +93,7 @@ function Turret:aimAtTarget (target, fallback)
 end
 
 function Turret:canFire ()
-  return not Config.game.gamePaused and self.cooldown <= 0
+  return not Config.game.gamePaused and self.cooldown <= 0 and self:getParent():getCharge() >= Config.game.pulseCharge
 end
 
 function Turret:fire ()
@@ -108,6 +108,10 @@ function Turret:fire ()
   assert(effect.dir:length() >= 0.9)
   effect.lifeMax = self.projLife
   effect.life = effect.lifeMax
+
+  -- Reduce capacitor charge if energy weapon
+  -- TODO: extend to different weapon types
+  self:getParent():discharge(Config.game.pulseCharge)
 
   if projectile then
     projectile.pos  = effect.pos

--- a/script/States/App/LTheoryRedux.lua
+++ b/script/States/App/LTheoryRedux.lua
@@ -70,6 +70,16 @@ function LTheoryRedux:toggleSound ()
   end
 end
 
+function LTheoryRedux:SoundOn ()
+  Config.audio.bSoundOn = true
+  MusicPlayer:SetVolume(1)
+end
+
+function LTheoryRedux:SoundOff ()
+  Config.audio.bSoundOn = false
+  MusicPlayer:SetVolume(0)
+end
+
 function LTheoryRedux:onInput ()
   self.canvas:input()
 end
@@ -200,6 +210,8 @@ function LTheoryRedux:onUpdate (dt)
     if not MainMenu.inBackgroundMode then
       if MainMenu.seedDialogDisplayed then
         MainMenu:ShowSeedDialog()
+      elseif MainMenu.settingsScreenDisplayed then
+        MainMenu:ShowSettingsScreen()
       else
         MainMenu:ShowGui()
       end
@@ -209,6 +221,8 @@ function LTheoryRedux:onUpdate (dt)
       MainMenu:ShowFlightDialog()
     elseif MainMenu.seedDialogDisplayed then
       MainMenu:ShowSeedDialog()
+    elseif MainMenu.settingsScreenDisplayed then
+      MainMenu:ShowSettingsScreen()
     end
   end
   HmGui.End()

--- a/script/States/Application.lua
+++ b/script/States/Application.lua
@@ -154,10 +154,8 @@ function Application:run ()
 
       if Config.game.gamePaused then
         timeScale = 0.0
-        self.window:setWindowGrab(false)
       else
         timeScale = 1.0
-        self.window:setWindowGrab(true)
       end
 
       if Input.GetDown(Bindings.TimeAccel) then

--- a/script/Systems/Controls/Controls/DockControl.lua
+++ b/script/Systems/Controls/Controls/DockControl.lua
@@ -32,13 +32,25 @@ end
 function DockControl:onDraw (focus, active)
   -- TODO : Unify this with HUD
   local x, y, sx, sy = self:getRectGlobal()
+  local cx, cy = sx / 2, sy / 2
+
+  local dockText = "Press J to Undock" -- TODO: Connect Undocking input to bindings
+
   UI.DrawEx.TextAdditive(
-    'NovaMono',
-    'Press J to Undock', -- TODO: connect Undocking input to bindings
-    16,
-    x, y, sx, sy,
+    "NovaMono",
+    dockText,
+    24,
+    cx, cy - 68, 1, 1,
+    0, 0, 0, 1,
+    0.5, 0.5
+  )
+  UI.DrawEx.TextAdditive(
+    "NovaMono",
+    dockText,
+    24,
+    cx, cy - 68, 1, 1,
     1, 1, 1, 1,
-    0.5, 0.96
+    0.5, 0.5
   )
 end
 

--- a/script/Systems/Menus/MainMenu.lua
+++ b/script/Systems/Menus/MainMenu.lua
@@ -26,10 +26,23 @@ local guiElements = {
   }
 }
 
+local guiSettings = {
+  { false, nil }, -- checkbox for audio toggle
+  { false, nil }, -- checkbox for unique ships toggle
+  { 0, nil }, -- value for number of asteroid fields
+  { 0, nil }, -- value for number of asteroids per field
+  { 0, nil }, -- value for number of planets
+  { 0, nil }, -- value for number of stations
+  { 0, nil }, -- value for number of AI Players
+  { 0, nil }, -- value for number of EconNPCs
+  { 0, nil }, -- value for number of EscortNPCs
+}
+
 function MainMenu:OnInit()
   self.enabled = true
   self.inBackgroundMode = false
   self.seedDialogDisplayed = false
+  self.settingsScreenDisplayed = false
   self.dt = 0
   self.lastActionDelta = 0
   self.returnToSplashDelta = 0
@@ -150,6 +163,7 @@ function MainMenu:ShowMainMenuInner()
   end
 
   if HmGui.Button("SETTINGS") then
+    self:ShowSettingsScreen()
   end
 
   if HmGui.Button("CREDITS") then
@@ -220,6 +234,7 @@ function MainMenu:ShowSeedDialogInner()
       Input.SetMouseVisible(false)
     end
   end
+
   HmGui.SetSpacing(16)
 
   if HmGui.Button("Random Seed") then
@@ -236,6 +251,7 @@ function MainMenu:ShowSeedDialogInner()
     Input.SetMouseVisible(false)
     LTheoryRedux:createStarSystem()
   end
+
   HmGui.SetSpacing(16)
 
   if HmGui.Button("Use Seed") then
@@ -251,8 +267,307 @@ function MainMenu:ShowSeedDialogInner()
     Input.SetMouseVisible(false)
     LTheoryRedux:createStarSystem()
   end
+
   HmGui.PopStyle(2)
   HmGui.EndGroup()
+  HmGui.SetAlign(0.5, 0.5)
+  HmGui.PopStyle(2)
+  HmGui.EndGroup()
+end
+
+function MainMenu:ShowSettingsScreen()
+  -- Add new star system seed selection dialog menu
+  self.settingsScreenDisplayed = true
+
+  HmGui.BeginWindow(guiElements.name)
+  HmGui.TextEx(Cache.Font('Iceland', 42), 'Settings', 0.3, 0.6, 1.0, 1.0)
+  HmGui.SetAlign(0.5, 0.5)
+  HmGui.SetSpacing(16)
+  self:ShowSettingsScreenInner()
+  HmGui.EndWindow()
+  HmGui.SetAlign(0.5, 0.5)
+end
+
+function MainMenu:ShowSettingsScreenInner()
+  -- Add new star system seed selection dialog menu items
+  HmGui.BeginGroupY()
+  HmGui.PushTextColor(1.0, 1.0, 1.0, 1.0)
+  HmGui.PushFont(Cache.Font('Exo2', 24))
+
+  -- Show Settings options
+  HmGui.BeginGroupY()
+
+  -- Create the new checkbox and save a reference to its current state (T/F)
+  HmGui.TextEx(Cache.Font('Exo2', 24), "----- Audio -----", 0.3, 0.6, 1.0, 1.0)
+  guiSettings[1][1] = Config.audio.bSoundOn
+  if guiSettings[1][2] == nil then
+    guiSettings[1][2] = Config.audio.bSoundOn
+  end
+  guiSettings[1][1] = HmGui.Checkbox("Music On/Off", guiSettings[1][1])
+  if guiSettings[1][1] then
+    -- Checkbox was selected
+    if not Config.audio.bSoundOn then
+      LTheoryRedux:SoundOn()
+    end
+  else
+    if Config.audio.bSoundOn then
+      LTheoryRedux:SoundOff()
+    end
+  end
+
+  if MainMenu.currentMode ~= Enums.MenuMode.Dialog then
+    -- Don't display game generation settings when viewing Settings in Flight mode
+    HmGui.SetSpacing(16)
+    HmGui.TextEx(Cache.Font('Exo2', 24), "--- Generation ---", 0.3, 0.6, 1.0, 1.0)
+
+    HmGui.SetSpacing(8)
+    guiSettings[2][1] = Config.gen.uniqueShips
+    if guiSettings[2][2] == nil then
+      guiSettings[2][2] = Config.gen.uniqueShips
+    end
+    guiSettings[2][1] = HmGui.Checkbox("Unique Ships", guiSettings[2][1])
+    if guiSettings[2][1] then
+      -- Checkbox was selected
+      if not Config.gen.uniqueShips then
+        Config.gen.uniqueShips = true
+      end
+    else
+      if Config.gen.uniqueShips then
+        Config.gen.uniqueShips = false
+      end
+    end
+
+    HmGui.SetSpacing(8)
+    HmGui.BeginGroupX()
+    HmGui.TextEx(Cache.Font('Exo2', 24), "Asteroid Fields: ", 1.0, 1.0, 1.0, 1.0)
+    HmGui.SetStretch(1.0, 0.0)
+    HmGui.BeginGroupX()
+    if guiSettings[3][2] == nil then
+      guiSettings[3][1] = Config.gen.nFields
+      guiSettings[3][2] = Config.gen.nFields
+    end
+    if HmGui.Button("-") and guiSettings[3][1] > 0 then
+      guiSettings[3][1] = guiSettings[3][1] - 1
+    end
+    HmGui.TextEx(Cache.Font("Ubuntu", 20), tostring(guiSettings[3][1]), 0.3, 1.0, 0.4, 1.0)
+    if HmGui.Button("+") and guiSettings[3][1] < 20 then
+      guiSettings[3][1] = guiSettings[3][1] + 1
+    end
+    HmGui.EndGroup()
+    HmGui.EndGroup()
+    HmGui.SetStretch(1.0, 0.0)
+
+    HmGui.SetSpacing(8)
+    HmGui.BeginGroupX()
+    HmGui.TextEx(Cache.Font('Exo2', 24), "Asteroids per field: ", 1.0, 1.0, 1.0, 1.0)
+    HmGui.SetStretch(1.0, 0.0)
+    HmGui.BeginGroupX()
+    if guiSettings[4][2] == nil then
+      guiSettings[4][1] = Config.gen.nAsteroids
+      guiSettings[4][2] = Config.gen.nAsteroids
+    end
+    if HmGui.Button("-") and guiSettings[4][1] > 1 then
+      guiSettings[4][1] = guiSettings[4][1] - 1
+    end
+    HmGui.TextEx(Cache.Font("Ubuntu", 20), tostring(guiSettings[4][1]), 0.3, 1.0, 0.4, 1.0)
+    if HmGui.Button("+") and guiSettings[4][1] < 200 then
+      guiSettings[4][1] = guiSettings[4][1] + 1
+    end
+    HmGui.EndGroup()
+    HmGui.EndGroup()
+    HmGui.SetStretch(1.0, 0.0)
+
+    HmGui.SetSpacing(8)
+    HmGui.BeginGroupX()
+    HmGui.TextEx(Cache.Font('Exo2', 24), "Planets: ", 1.0, 1.0, 1.0, 1.0)
+    HmGui.SetStretch(1.0, 0.0)
+    HmGui.BeginGroupX()
+    if guiSettings[5][2] == nil then
+      guiSettings[5][1] = Config.gen.nPlanets
+      guiSettings[5][2] = Config.gen.nPlanets
+    end
+    if HmGui.Button("-") and guiSettings[5][1] > 0 then
+      guiSettings[5][1] = guiSettings[5][1] - 1
+    end
+    HmGui.TextEx(Cache.Font("Ubuntu", 20), tostring(guiSettings[5][1]), 0.3, 1.0, 0.4, 1.0)
+    if HmGui.Button("+") and guiSettings[5][1] < 1 then
+      guiSettings[5][1] = guiSettings[5][1] + 1
+    end
+    HmGui.EndGroup()
+    HmGui.EndGroup()
+    HmGui.SetStretch(1.0, 0.0)
+
+    HmGui.SetSpacing(8)
+    HmGui.BeginGroupX()
+    HmGui.TextEx(Cache.Font('Exo2', 24), "Space Stations: ", 1.0, 1.0, 1.0, 1.0)
+    HmGui.SetStretch(1.0, 0.0)
+    HmGui.BeginGroupX()
+    if guiSettings[6][2] == nil then
+      guiSettings[6][1] = Config.gen.nStations
+      guiSettings[6][2] = Config.gen.nStations
+    end
+    if HmGui.Button("-") and guiSettings[6][1] > 0 then
+      guiSettings[6][1] = guiSettings[6][1] - 1
+    end
+    HmGui.TextEx(Cache.Font("Ubuntu", 20), tostring(guiSettings[6][1]), 0.3, 1.0, 0.4, 1.0)
+    if HmGui.Button("+") and guiSettings[6][1] < 50 then
+      guiSettings[6][1] = guiSettings[6][1] + 1
+    end
+    HmGui.EndGroup()
+    HmGui.EndGroup()
+    HmGui.SetStretch(1.0, 0.0)
+
+    HmGui.SetSpacing(8)
+    HmGui.BeginGroupX()
+    HmGui.TextEx(Cache.Font('Exo2', 24), "AI Players: ", 1.0, 1.0, 1.0, 1.0)
+    HmGui.SetStretch(1.0, 0.0)
+    HmGui.BeginGroupX()
+    if guiSettings[7][2] == nil then
+      guiSettings[7][1] = Config.gen.nAIPlayers
+      guiSettings[7][2] = Config.gen.nAIPlayers
+    end
+    if HmGui.Button("-") and guiSettings[7][1] > 0 then
+      guiSettings[7][1] = guiSettings[7][1] - 1
+    end
+    HmGui.TextEx(Cache.Font("Ubuntu", 20), tostring(guiSettings[7][1]), 0.3, 1.0, 0.4, 1.0)
+    if HmGui.Button("+") and guiSettings[7][1] < 20 then
+      guiSettings[7][1] = guiSettings[7][1] + 1
+    end
+    HmGui.EndGroup()
+    HmGui.EndGroup()
+    HmGui.SetStretch(1.0, 0.0)
+
+    HmGui.SetSpacing(8)
+    HmGui.BeginGroupX()
+    HmGui.TextEx(Cache.Font('Exo2', 24), "Economic NPCs: ", 1.0, 1.0, 1.0, 1.0)
+    HmGui.SetStretch(1.0, 0.0)
+    HmGui.BeginGroupX()
+    if guiSettings[8][2] == nil then
+      guiSettings[8][1] = Config.gen.nEconNPCs
+      guiSettings[8][2] = Config.gen.nEconNPCs
+    end
+    if HmGui.Button("-") and guiSettings[8][1] > 0 then
+      guiSettings[8][1] = guiSettings[8][1] - 1
+    end
+    HmGui.TextEx(Cache.Font("Ubuntu", 20), tostring(guiSettings[8][1]), 0.3, 1.0, 0.4, 1.0)
+    if HmGui.Button("+") and guiSettings[8][1] < 100 then
+      guiSettings[8][1] = guiSettings[8][1] + 1
+    end
+    HmGui.EndGroup()
+    HmGui.EndGroup()
+    HmGui.SetStretch(1.0, 0.0)
+
+    HmGui.SetSpacing(8)
+    HmGui.BeginGroupX()
+    HmGui.TextEx(Cache.Font('Exo2', 24), "Escort NPCs: ", 1.0, 1.0, 1.0, 1.0)
+    HmGui.SetStretch(1.0, 0.0)
+    HmGui.BeginGroupX()
+    if guiSettings[9][2] == nil then
+      guiSettings[9][1] = Config.gen.nEscortNPCs
+      guiSettings[9][2] = Config.gen.nEscortNPCs
+    end
+    if HmGui.Button("-") and guiSettings[9][1] > 0 then
+      guiSettings[9][1] = guiSettings[9][1] - 1
+    end
+    HmGui.TextEx(Cache.Font("Ubuntu", 20), tostring(guiSettings[9][1]), 0.3, 1.0, 0.4, 1.0)
+    if HmGui.Button("+") and guiSettings[9][1] < 50 then
+      guiSettings[9][1] = guiSettings[9][1] + 1
+    end
+    HmGui.EndGroup()
+    HmGui.EndGroup()
+    HmGui.SetStretch(1.0, 0.0)
+
+  end
+
+  HmGui.EndGroup()
+
+  -- Show Settings control buttons
+  HmGui.SetSpacing(16)
+  HmGui.BeginGroupX()
+  HmGui.PushTextColor(1.0, 1.0, 1.0, 1.0)
+  HmGui.PushFont(Cache.Font('Exo2Bold', 28))
+
+  if HmGui.Button("Cancel") then
+    -- Revert to the pre-Settings values of each setting
+    if guiSettings[1][2] then
+      LTheoryRedux:SoundOn()
+    else
+      LTheoryRedux:SoundOff()
+    end
+
+    if MainMenu.currentMode ~= Enums.MenuMode.Dialog then
+      if guiSettings[2][2] then
+        Config.gen.uniqueShips = true
+      else
+        Config.gen.uniqueShips = false
+      end
+      Config.gen.nFields     = guiSettings[3][2]
+      Config.gen.nAsteroids  = guiSettings[4][2]
+      Config.gen.nPlanets    = guiSettings[5][2]
+      Config.gen.nStations   = guiSettings[6][2]
+      Config.gen.nAIPlayers  = guiSettings[7][2]
+      Config.gen.nEconNPCs   = guiSettings[8][2]
+      Config.gen.nEscortNPCs = guiSettings[9][2]
+    end
+
+    guiSettings[1][2] = nil
+    guiSettings[2][2] = nil
+    guiSettings[3][2] = nil
+    guiSettings[4][2] = nil
+    guiSettings[5][2] = nil
+    guiSettings[6][2] = nil
+    guiSettings[7][2] = nil
+    guiSettings[8][2] = nil
+    guiSettings[9][2] = nil
+
+    self.settingsScreenDisplayed = false
+    Config.game.gamePaused = false
+
+    if MainMenu.currentMode == Enums.MenuMode.Dialog then
+      LTheoryRedux:freezeTurrets()
+      Config.setGameMode(2) -- return to Flight Mode
+      Config.game.flightModeButInactive = false
+      Input.SetMouseVisible(false)
+    end
+  end
+
+  HmGui.SetSpacing(16)
+
+  if HmGui.Button("Use") then
+    self.settingsScreenDisplayed = false
+    Config.game.gamePaused = false
+
+    if MainMenu.currentMode ~= Enums.MenuMode.Dialog then
+      Config.gen.nFields     = guiSettings[3][1]
+      Config.gen.nAsteroids  = guiSettings[4][1]
+      Config.gen.nPlanets    = guiSettings[5][1]
+      Config.gen.nStations   = guiSettings[6][1]
+      Config.gen.nAIPlayers  = guiSettings[7][1]
+      Config.gen.nEconNPCs   = guiSettings[8][1]
+      Config.gen.nEscortNPCs = guiSettings[9][1]
+    end
+
+    guiSettings[1][2] = nil
+    guiSettings[2][2] = nil
+    guiSettings[3][2] = nil
+    guiSettings[4][2] = nil
+    guiSettings[5][2] = nil
+    guiSettings[6][2] = nil
+    guiSettings[7][2] = nil
+    guiSettings[8][2] = nil
+    guiSettings[9][2] = nil
+
+    if MainMenu.currentMode == Enums.MenuMode.Dialog then
+      LTheoryRedux:freezeTurrets()
+      Config.setGameMode(2) -- return to Flight Mode
+      Config.game.flightModeButInactive = false
+      Input.SetMouseVisible(false)
+    end
+  end
+
+  HmGui.PopStyle(2)
+  HmGui.EndGroup()
+
   HmGui.SetAlign(0.5, 0.5)
   HmGui.PopStyle(2)
   HmGui.EndGroup()
@@ -311,11 +626,9 @@ function MainMenu:ShowFlightDialogInner()
   HmGui.SetSpacing(8)
 
   if HmGui.Button("Game Settings") then
-    -- TODO: Show Game Settings menu once that's been implemented
-    LTheoryRedux:freezeTurrets()
+    -- Show Game Settings menu
+    self:ShowSettingsScreen()
     Config.game.flightModeButInactive = false
-    Config.game.gamePaused = false
-    Input.SetMouseVisible(false)
   end
   HmGui.SetSpacing(8)
 
@@ -332,6 +645,24 @@ function MainMenu:ShowFlightDialogInner()
   end
   HmGui.PopStyle(2)
   HmGui.EndGroup()
+end
+
+function MainMenu:utf8 (decimal)
+  local bytemarkers = { {0x7FF,192}, {0xFFFF,224}, {0x1FFFFF,240} }
+  if decimal<128 then return string.char(decimal) end
+  local charbytes = {}
+  for bytes,vals in ipairs(bytemarkers) do
+    if decimal<=vals[1] then
+      for b=bytes+1,2,-1 do
+        local mod = decimal%64
+        decimal = (decimal-mod)/64
+        charbytes[b] = string.char(128+mod)
+      end
+      charbytes[1] = string.char(vals[2]+decimal)
+      break
+    end
+  end
+  return table.concat(charbytes)
 end
 
 return MainMenu

--- a/script/Systems/Overlay/HUD.lua
+++ b/script/Systems/Overlay/HUD.lua
@@ -127,7 +127,7 @@ function HUD:drawBoostEnergy (a)
   UI.DrawEx.MeterV(hudX, hudY, mvWidth, mvHeight, Config.ui.color.remainingBoost, mvSpacing, mvLevels, 7)
 end
 
-function HUD:drawWeaponEnergy (a)
+function HUD:drawCapacitorEnergy (a)
   local cx, cy = self.sx / 2, self.sy / 2
 
   local mvWidth   = 24
@@ -157,8 +157,12 @@ function HUD:drawWeaponEnergy (a)
     hudY      = cy
   end
 
+  local player = self.player
+  local playerShip = player:getControlling()
+  local capacitorPctBar = floor(playerShip:getChargePercent() / 10)
+
   UI.DrawEx.RectOutline(hudX - 6, hudY - mvYtot + mvHeight + 4, mvWidth + 12, mvYtot, Config.ui.color.borderBright)
-  UI.DrawEx.MeterV(hudX, hudY, mvWidth, mvHeight, Config.ui.color.remainingEnergy, mvSpacing, mvLevels, 9)
+  UI.DrawEx.MeterV(hudX, hudY, mvWidth, mvHeight, Config.ui.color.remainingEnergy, mvSpacing, mvLevels, capacitorPctBar)
 end
 
 function HUD:drawTargetType (a)
@@ -430,6 +434,11 @@ function HUD:drawPlayerShieldsHullArmor (a)
   local cx, cy = self.sx / 2, self.sy / 2
   local text = ""
 
+  local sensorsHeight = 0
+  if Config.ui.sensorsDisplayed then
+    sensorsHeight = floor(self.sy / 9)
+  end
+
   local hudXs = 0
   local hudXh = 0
   local hudXa = 0
@@ -439,7 +448,7 @@ function HUD:drawPlayerShieldsHullArmor (a)
     hudXs = cx - 100
     hudXh = cx
     hudXa = cx + 100
-    hudY  = self.sy - 160 - floor(self.sy / 9) - 74
+    hudY  = self.sy - 160 - sensorsHeight - 74
     hudFsize = hudFontSize
   elseif Config.ui.hudDisplayed == Enums.HudModes.Balanced then
     hudXs = cx - 100
@@ -483,16 +492,21 @@ function HUD:drawMissilesLeft (a)
 
   local cx, cy = self.sx / 2, self.sy / 2
 
+  local sensorsHeight = 0
+  if Config.ui.sensorsDisplayed then
+    sensorsHeight = floor(self.sy / 9)
+  end
+
   local hudX = 0
   local hudY = 0
   local hudFsize = hudFontSize
   if Config.ui.hudDisplayed == Enums.HudModes.Wide then
     hudX = cx - 150
-    hudY = self.sy - 160 - floor(self.sy / 9) - 24
+    hudY = self.sy - 160 - sensorsHeight - 24
     hudFsize = hudFontSize
   elseif Config.ui.hudDisplayed == Enums.HudModes.Balanced then
     hudX = cx - 150
-    hudY = self.sy - 160 - floor(self.sy / 9) - 24
+    hudY  = self.sy - 160 - floor(self.sy / 9) - 24
     hudFsize = hudFontSize
   elseif Config.ui.hudDisplayed == Enums.HudModes.Tight then
     hudX = cx - 150
@@ -512,16 +526,21 @@ function HUD:drawPlayerSpeed (a)
 
   local cx, cy = self.sx / 2, self.sy / 2
 
+  local sensorsHeight = 0
+  if Config.ui.sensorsDisplayed then
+    sensorsHeight = floor(self.sy / 9)
+  end
+
   local hudX = 0
   local hudY = 0
   local hudFsize = hudFontSize
   if Config.ui.hudDisplayed == Enums.HudModes.Wide then
     hudX = cx
-    hudY = self.sy - 160 - floor(self.sy / 9) - 24
+    hudY = self.sy - 160 - sensorsHeight - 24
     hudFsize = hudFontSize
   elseif Config.ui.hudDisplayed == Enums.HudModes.Balanced then
     hudX = cx
-    hudY = self.sy - 160 - floor(self.sy / 9) - 24
+    hudY  = self.sy - 160 - floor(self.sy / 9) - 24
     hudFsize = hudFontSize
   elseif Config.ui.hudDisplayed == Enums.HudModes.Tight then
     hudX = cx
@@ -540,16 +559,21 @@ function HUD:drawChaffLeft (a)
 
   local cx, cy = self.sx / 2, self.sy / 2
 
+  local sensorsHeight = 0
+  if Config.ui.sensorsDisplayed then
+    sensorsHeight = floor(self.sy / 9)
+  end
+
   local hudX = 0
   local hudY = 0
   local hudFsize = hudFontSize
   if Config.ui.hudDisplayed == Enums.HudModes.Wide then
     hudX = cx + 150
-    hudY = self.sy - 160 - floor(self.sy / 9) - 24
+    hudY = self.sy - 160 - sensorsHeight - 24
     hudFsize = hudFontSize
   elseif Config.ui.hudDisplayed == Enums.HudModes.Balanced then
     hudX = cx + 150
-    hudY = self.sy - 160 - floor(self.sy / 9) - 24
+    hudY  = self.sy - 160 - floor(self.sy / 9) - 24
     hudFsize = hudFontSize
   elseif Config.ui.hudDisplayed == Enums.HudModes.Tight then
     hudX = cx + 150
@@ -708,18 +732,18 @@ function HUD:drawPowerDistro (a)
 
   -- Draw player power distribution
   HUD:drawHudTextDouble(hudXLt, hudYAt, Config.ui.color.meterBar, hudFsize, 0.0, "Engines")
-  HUD:drawHudTextDouble(hudXLt, hudYBt, Config.ui.color.meterBar, hudFsize, 0.0, "Shields")
-  HUD:drawHudTextDouble(hudXRt, hudYAt, Config.ui.color.meterBar, hudFsize, 0.0, "Computer")
-  HUD:drawHudTextDouble(hudXRt, hudYBt, Config.ui.color.meterBar, hudFsize, 0.0, "Sensors")
+  HUD:drawHudTextDouble(hudXLt, hudYBt, Config.ui.color.meterBar, hudFsize, 0.0, "Sensors")
+  HUD:drawHudTextDouble(hudXRt, hudYAt, Config.ui.color.meterBar, hudFsize, 0.0, "Weapons")
+  HUD:drawHudTextDouble(hudXRt, hudYBt, Config.ui.color.meterBar, hudFsize, 0.0, "Shields")
 
-  UI.DrawEx.Meter(hudXLm, hudYAm, 32, 8, Config.ui.color.meterBar, 10, 4, 4, 1)
-  UI.DrawEx.Meter(hudXLm, hudYBm, 32, 8, Config.ui.color.meterBar, 10, 4, 2, 1)
-  UI.DrawEx.Meter(hudXRm, hudYAm, 32, 8, Config.ui.color.meterBar, 10, 4, 1, -1)
-  UI.DrawEx.Meter(hudXRm, hudYBm, 32, 8, Config.ui.color.meterBar, 10, 4, 1, -1)
+  UI.DrawEx.Meter(hudXLm, hudYAm, 32, 8, Config.ui.color.meterBar, 10, 4, 4, true, Config.ui.color.meterBarOver,  1)
+  UI.DrawEx.Meter(hudXLm, hudYBm, 32, 8, Config.ui.color.meterBar, 10, 4, 1, true, Config.ui.color.meterBarOver,  1)
+  UI.DrawEx.Meter(hudXRm, hudYAm, 32, 8, Config.ui.color.meterBar, 10, 4, 4, true, Config.ui.color.meterBarOver, -1)
+  UI.DrawEx.Meter(hudXRm, hudYBm, 32, 8, Config.ui.color.meterBar, 10, 4, 3, true, Config.ui.color.meterBarOver, -1)
 end
 
 function HUD:drawSensors (a)
-  if Config.ui.SensorsDisplayed then
+  if Config.ui.sensorsDisplayed then
     local cx, cy = self.sx / 2, self.sy / 2
 
     -- Draw sensor readouts
@@ -735,6 +759,7 @@ end
 function HUD:drawTacticalMap (a)
   local cx, cy = self.sx / 2, self.sy / 2
 
+  -- Draw tactical map
   UI.DrawEx.Ring(cx     , self.sy - 76, 70, Config.ui.color.meterBar, true)
   UI.DrawEx.Ring(cx     , self.sy - 76, 44, Config.ui.color.meterBar, false)
 
@@ -900,9 +925,8 @@ function HUD:drawLock (a)
     local ndc = camera:worldToNDC(pos)
     local ndcMax = max(abs(ndc.x), abs(ndc.y))
 
-    -- NOTE: flip arrow direction arrow when target in rear hemisphere relative to player view
+    -- NOTE: invert direction arrow when target in rear hemisphere relative to player view
     if ndc.z <= 0 then ndc:idivs(-ndcMax) end
---    if ndcMax > 1 or ndc.z <= 0 then ndc:idivs(ndcMax) end
 
     local ss = camera:ndcToScreen(ndc)
     local dir = ss - center
@@ -975,8 +999,8 @@ function HUD:drawReticle (a)
 end
 
 function HUD:drawPlayerHealth (a)
-  local cx, cy = self.sx / 2, self.sy / 2
   local x, y, sx, sy = self:getRectGlobal()
+  local cx, cy = sx / 2, sy / 2
   local playerShip = self.player:getControlling()
   local playerRadius = playerShip:getRadius()
   local playerHealthPct = playerShip:getHealthPercent()
@@ -1006,7 +1030,7 @@ function HUD:drawPlayerHealth (a)
 
   -- Draw player ship health as a meter
   UI.DrawEx.RectOutline(66, sy - 36, 202, 22, Config.ui.color.borderBright)
-  UI.DrawEx.Meter(72, sy - 30, 10, 10, hc, 10, 10, floor(playerHealthPct / 10), 1)
+  UI.DrawEx.Meter(72, sy - 30, 10, 10, hc, 10, 10, floor(playerHealthPct / 10), false, nil, 1)
 
   -- TEMP: Also draw the player ship's health bar under the central reticle
 --  UI.DrawEx.RectOutline(cx - 22, cy + 18, 44, 8, Config.ui.color.borderDim)
@@ -1018,8 +1042,8 @@ function HUD:drawTargetHealth (a)
   local playerShip = self.player:getControlling()
   local target = playerShip:getTarget()
   if target and target:hasHealth() and not target:isDestroyed() then
-    local cx, cy = self.sx / 2, self.sy / 2
     local x, y, sx, sy = self:getRectGlobal()
+    local cx, cy = sx / 2, sy / 2
     local targetRangeText = ""
     if playerShip:getDistance(target) >= 1000 then
       targetRangeText = format("Range: %d km", floor(playerShip:getDistance(target) / 1000 + 0.5))
@@ -1063,13 +1087,14 @@ function HUD:drawTargetHealth (a)
 
       -- Draw target health as a meter
       UI.DrawEx.RectOutline(sx - 254, sy - 36, 202, 22, Config.ui.color.borderBright)
-      UI.DrawEx.Meter(sx - 250, sy - 30, 10, 10, hc, 10, 10, floor(targetHealthPct / 10), 1)
+      UI.DrawEx.Meter(sx - 250, sy - 30, 10, 10, hc, 10, 10, floor(targetHealthPct / 10), false, nil, 1)
     end
   end
 end
 
 function HUD:drawDockPrompt (a)
   local x, y, sx, sy = self:getRectGlobal()
+  local cx, cy = sx / 2, sy / 2
   local dockText = nil
 
   if dockingAllowed then
@@ -1081,18 +1106,18 @@ function HUD:drawDockPrompt (a)
   UI.DrawEx.TextAdditive(
     "NovaMono",
     dockText,
-    16,
-    x, y, sx, sy,
+    24,
+    cx, cy - 68, 1, 1,
     0, 0, 0, self.dockPromptAlpha * a,
-    0.5, 0.96
+    0.5, 0.5
   )
   UI.DrawEx.TextAdditive(
     "NovaMono",
     dockText,
-    16,
-    x, y, sx, sy,
+    24,
+    cx, cy - 68, 1, 1,
     1, 1, 1, self.dockPromptAlpha * a,
-    0.5, 0.96
+    0.5, 0.5
   )
 end
 
@@ -1155,7 +1180,7 @@ function HUD:onUpdate (state)
     end
 
     if Input.GetPressed(Bindings.ToggleSensors) then
-      Config.ui.SensorsDisplayed = not Config.ui.SensorsDisplayed
+      Config.ui.sensorsDisplayed = not Config.ui.sensorsDisplayed
     end
 
     self.targets:update()
@@ -1216,7 +1241,7 @@ function HUD:onDraw (focus, active)
       self:drawSystemText            (self.enabled)
       self:drawTargetText            (self.enabled)
       self:drawBoostEnergy           (self.enabled)
-      self:drawWeaponEnergy          (self.enabled)
+      self:drawCapacitorEnergy       (self.enabled)
       self:drawTargetMission         (self.enabled)
       self:drawTargetType            (self.enabled)
       self:drawTargetRange           (self.enabled)

--- a/script/UI/DrawEx.lua
+++ b/script/UI/DrawEx.lua
@@ -134,7 +134,7 @@ function DrawEx.Line (x1, y1, x2, y2, color, fade)
   BlendMode.Pop()
 end
 
-function DrawEx.Meter (x, y, sx, sy, color, spacing, total, level, direction)
+function DrawEx.Meter (x, y, sx, sy, color, spacing, total, level, overcharge, overchargeColor, direction)
   -- NOTE: There must be a more elegant way to do this, but brain will not brain today
   local filled = level
   if direction == -1 then
@@ -143,14 +143,22 @@ function DrawEx.Meter (x, y, sx, sy, color, spacing, total, level, direction)
       if i <= filled then
         DrawEx.PanelGlow(x, y, sx, sy, color)
       else
-        DrawEx.Rect(x, y, sx, sy, color)
+        if overcharge and i == 1 then
+          DrawEx.Rect(x, y, sx, sy, overchargeColor)
+        else
+          DrawEx.Rect(x, y, sx, sy, color)
+        end
       end
       x = x + sx + spacing
     end
   else
     for i = 1, total do
       if i <= filled then
-        DrawEx.Rect(x, y, sx, sy, color)
+        if overcharge and i == total then
+          DrawEx.Rect(x, y, sx, sy, overchargeColor)
+        else
+          DrawEx.Rect(x, y, sx, sy, color)
+        end
       else
         DrawEx.PanelGlow(x, y, sx, sy, color)
       end


### PR DESCRIPTION
* Made a first start at enabling Settings. Several of the values stored in user.ini can now be adjusted in Settings. Note that although Settings can be displayed from both the Main Menu and in Flight mode, ship generation settings are only displayed from the Main Menu.
* Hooked up the previously unused Capacitor feature to ships. Now energy weapons (currently only Pulse Turrets) draw power from the ship's capacitor, and can only fire as long as there's energy left (which recharges automatically). For the player's ship, the current capacitor energy remaining is now displayed in the HUD.
* Power Allocation settings now have an "overcharge" value. There's no active functionality here yet -- this is just enhancing the HUD to show when a ship's component is overcharged.