### PR TITLE
Rewrite the signal handler code using safe Rust HashMaps

### DIFF
--- a/libphx/src/Profiler.rs
+++ b/libphx/src/Profiler.rs
@@ -74,8 +74,10 @@ unsafe extern "C" fn Profiler_GetScope(name: *const libc::c_char) -> *mut Scope 
     scope
 }
 
-unsafe extern "C" fn Profiler_SignalHandler(_s: Signal) {
-    Profiler_Backtrace();
+extern "C" fn Profiler_SignalHandler(_: Signal) {
+    unsafe {
+        Profiler_Backtrace();
+    }
 }
 
 #[no_mangle]
@@ -90,9 +92,7 @@ pub unsafe extern "C" fn Profiler_Enable() {
     this.stackIndex = -1;
     this.start = TimeStamp_Get();
     Profiler_Begin(c_str!("[Root]"));
-    Signal_AddHandlerAll(Some(
-        Profiler_SignalHandler as unsafe extern "C" fn(Signal) -> (),
-    ));
+    Signal_AddHandlerAll(Profiler_SignalHandler);
 }
 
 #[no_mangle]
@@ -151,9 +151,7 @@ pub unsafe extern "C" fn Profiler_Disable() {
     }
     HashMap_Free(this.map);
     profiling = false;
-    Signal_RemoveHandlerAll(Some(
-        Profiler_SignalHandler as unsafe extern "C" fn(Signal) -> (),
-    ));
+    Signal_RemoveHandlerAll(Profiler_SignalHandler);
 }
 
 #[no_mangle]

--- a/libphx/src/Signal.rs
+++ b/libphx/src/Signal.rs
@@ -1,197 +1,142 @@
+use crate::internal::ffi;
 use crate::internal::Memory::*;
 use crate::Common::*;
-
-extern "C" {
-    fn signal(
-        _: i32,
-        _: Option<unsafe extern "C" fn(i32) -> ()>,
-    ) -> Option<unsafe extern "C" fn(i32) -> ()>;
-}
+use std::collections::HashMap;
 
 pub type Signal = i32;
-pub type SignalHandler = Option<unsafe extern "C" fn(Signal) -> ()>;
+pub type SignalHandler = extern "C" fn(Signal) -> ();
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct HandlerElem {
-    pub next: *mut HandlerElem,
-    pub fn_0: SignalHandler,
-}
-
-#[no_mangle]
-pub static Signal_Ill: Signal = 4;
-
-#[no_mangle]
-pub static Signal_Fpe: Signal = 8;
-
-#[no_mangle]
-pub static Signal_Segv: Signal = 11;
-
-#[no_mangle]
-pub static Signal_Term: Signal = 15;
-
-#[no_mangle]
-pub static Signal_Abrt: Signal = 6;
-
-#[no_mangle]
-pub static Signal_Int: Signal = 2;
+pub const Signal_Int: Signal = libc::SIGINT;
+pub const Signal_Ill: Signal = libc::SIGILL;
+pub const Signal_Fpe: Signal = libc::SIGFPE;
+pub const Signal_Segv: Signal = libc::SIGSEGV;
+pub const Signal_Term: Signal = libc::SIGTERM;
+pub const Signal_Abrt: Signal = libc::SIGABRT;
 
 static mut ignoreDefault: bool = false;
+static mut handlerDefault: Option<HashMap<Signal, SignalHandler>> = None;
+static mut handlerTable: Option<HashMap<Signal, Vec<SignalHandler>>> = None;
 
-static mut handlerDefault: [SignalHandler; 32] = [
-    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-];
+fn HandlerDefault(signal: Signal) -> SignalHandler {
+    unsafe { *handlerDefault.as_ref().unwrap().get(&signal).unwrap() }
+}
 
-static mut handlerTable: [*mut HandlerElem; 32] = [
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-    std::ptr::null_mut(),
-];
+fn HandlerTable<'a>(signal: Signal) -> &'a mut Vec<SignalHandler> {
+    unsafe { handlerTable.as_mut().unwrap().get_mut(&signal).unwrap() }
+}
 
-unsafe extern "C" fn Signal_Handler(sig: Signal) {
-    CWarn!("Signal_Handler: Caught %s", Signal_ToString(sig));
-    signal(Signal_Int, handlerDefault[Signal_Int as usize]);
-    signal(Signal_Ill, handlerDefault[Signal_Ill as usize]);
-    signal(Signal_Fpe, handlerDefault[Signal_Fpe as usize]);
-    signal(Signal_Segv, handlerDefault[Signal_Segv as usize]);
-    signal(Signal_Term, handlerDefault[Signal_Term as usize]);
-    signal(Signal_Abrt, handlerDefault[Signal_Abrt as usize]);
-    let mut e: *mut HandlerElem = handlerTable[sig as usize];
-    while !e.is_null() {
-        ((*e).fn_0).expect("non-null function pointer")(sig);
-        e = (*e).next;
+fn Signal(signal: Signal, handler: SignalHandler) -> SignalHandler {
+    unsafe {
+        let ptr = libc::signal(signal, handler as *mut libc::c_void as libc::sighandler_t);
+        std::mem::transmute::<libc::sighandler_t, SignalHandler>(ptr)
     }
-    if ignoreDefault {
-        ignoreDefault = false;
-        return;
+}
+
+extern "C" fn Signal_Handler(sig: Signal) {
+    unsafe {
+        CWarn!("Signal_Handler: Caught %s", Signal_ToString(sig));
+
+        /* Re-install default handlers. */
+        Signal(Signal_Int, HandlerDefault(Signal_Int));
+        Signal(Signal_Ill, HandlerDefault(Signal_Ill));
+        Signal(Signal_Fpe, HandlerDefault(Signal_Fpe));
+        Signal(Signal_Segv, HandlerDefault(Signal_Segv));
+        Signal(Signal_Term, HandlerDefault(Signal_Term));
+        Signal(Signal_Abrt, HandlerDefault(Signal_Abrt));
+
+        /* Call custom handlers. */
+        for handler in HandlerTable(sig).iter() {
+            handler(sig);
+        }
+        if ignoreDefault {
+            ignoreDefault = false;
+            return;
+        }
+
+        /* Re-raise the signal to let the default handler run. */
+        libc::raise(sig);
     }
-    libc::raise(sig);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Signal_Init() {
-    handlerDefault[Signal_Int as usize] = signal(
-        Signal_Int,
-        Some(Signal_Handler as unsafe extern "C" fn(Signal) -> ()),
-    );
-    handlerDefault[Signal_Ill as usize] = signal(
-        Signal_Ill,
-        Some(Signal_Handler as unsafe extern "C" fn(Signal) -> ()),
-    );
-    handlerDefault[Signal_Fpe as usize] = signal(
-        Signal_Fpe,
-        Some(Signal_Handler as unsafe extern "C" fn(Signal) -> ()),
-    );
-    handlerDefault[Signal_Segv as usize] = signal(
-        Signal_Segv,
-        Some(Signal_Handler as unsafe extern "C" fn(Signal) -> ()),
-    );
-    handlerDefault[Signal_Term as usize] = signal(
-        Signal_Term,
-        Some(Signal_Handler as unsafe extern "C" fn(Signal) -> ()),
-    );
-    handlerDefault[Signal_Abrt as usize] = signal(
-        Signal_Abrt,
-        Some(Signal_Handler as unsafe extern "C" fn(Signal) -> ()),
-    );
+    handlerDefault = Some(HashMap::from([
+        (Signal_Int, Signal(Signal_Int, Signal_Handler)),
+        (Signal_Ill, Signal(Signal_Ill, Signal_Handler)),
+        (Signal_Fpe, Signal(Signal_Fpe, Signal_Handler)),
+        (Signal_Segv, Signal(Signal_Segv, Signal_Handler)),
+        (Signal_Term, Signal(Signal_Term, Signal_Handler)),
+        (Signal_Abrt, Signal(Signal_Abrt, Signal_Handler)),
+    ]));
+    handlerTable = Some(HashMap::from([
+        (Signal_Int, Vec::new()),
+        (Signal_Ill, Vec::new()),
+        (Signal_Fpe, Vec::new()),
+        (Signal_Segv, Vec::new()),
+        (Signal_Term, Vec::new()),
+        (Signal_Abrt, Vec::new()),
+    ]));
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Signal_Free() {
-    signal(Signal_Int, handlerDefault[Signal_Int as usize]);
-    signal(Signal_Ill, handlerDefault[Signal_Ill as usize]);
-    signal(Signal_Fpe, handlerDefault[Signal_Fpe as usize]);
-    signal(Signal_Segv, handlerDefault[Signal_Segv as usize]);
-    signal(Signal_Term, handlerDefault[Signal_Term as usize]);
-    signal(Signal_Abrt, handlerDefault[Signal_Abrt as usize]);
+    Signal(Signal_Int, HandlerDefault(Signal_Int));
+    Signal(Signal_Ill, HandlerDefault(Signal_Ill));
+    Signal(Signal_Fpe, HandlerDefault(Signal_Fpe));
+    Signal(Signal_Segv, HandlerDefault(Signal_Segv));
+    Signal(Signal_Term, HandlerDefault(Signal_Term));
+    Signal(Signal_Abrt, HandlerDefault(Signal_Abrt));
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Signal_AddHandler(sig: Signal, fn_0: SignalHandler) {
-    let e = MemNew!(HandlerElem);
-    (*e).next = handlerTable[sig as usize];
-    (*e).fn_0 = fn_0;
-    // handlerTable[sig as usize] = e;
+pub unsafe extern "C" fn Signal_AddHandler(sig: Signal, handler: SignalHandler) {
+    HandlerTable(sig).push(handler);
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Signal_AddHandlerAll(fn_0: SignalHandler) {
-    Signal_AddHandler(Signal_Int, fn_0);
-    Signal_AddHandler(Signal_Ill, fn_0);
-    Signal_AddHandler(Signal_Fpe, fn_0);
-    Signal_AddHandler(Signal_Segv, fn_0);
-    Signal_AddHandler(Signal_Term, fn_0);
-    Signal_AddHandler(Signal_Abrt, fn_0);
+pub unsafe extern "C" fn Signal_AddHandlerAll(handler: SignalHandler) {
+    Signal_AddHandler(Signal_Int, handler);
+    Signal_AddHandler(Signal_Ill, handler);
+    Signal_AddHandler(Signal_Fpe, handler);
+    Signal_AddHandler(Signal_Segv, handler);
+    Signal_AddHandler(Signal_Term, handler);
+    Signal_AddHandler(Signal_Abrt, handler);
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Signal_RemoveHandler(sig: Signal, fn_0: SignalHandler) {
-    let mut prev: *mut *mut HandlerElem =
-        &mut *handlerTable.as_mut_ptr().offset(sig as isize) as *mut *mut HandlerElem;
-    let mut curr: *mut HandlerElem = handlerTable[sig as usize];
-    while !curr.is_null() {
-        if (*curr).fn_0 == fn_0 {
-            *prev = (*curr).next;
-            return;
-        }
-        prev = &mut (*curr).next;
-        curr = (*curr).next;
+pub unsafe extern "C" fn Signal_RemoveHandler(sig: Signal, handler: SignalHandler) {
+    let mut handlers = HandlerTable(sig);
+    if let Some(pos) = handlers.iter().position(|f| *f == handler) {
+        handlers.remove(pos);
+    } else {
+        Fatal!(
+            "Signal_RemoveHandler: No such handler installed for signal {}",
+            ffi::PtrAsString(Signal_ToString(sig))
+        );
     }
-    CFatal!("Signal_RemoveHandler: No such handler installed");
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Signal_RemoveHandlerAll(fn_0: SignalHandler) {
-    Signal_RemoveHandler(Signal_Int, fn_0);
-    Signal_RemoveHandler(Signal_Ill, fn_0);
-    Signal_RemoveHandler(Signal_Fpe, fn_0);
-    Signal_RemoveHandler(Signal_Segv, fn_0);
-    Signal_RemoveHandler(Signal_Term, fn_0);
-    Signal_RemoveHandler(Signal_Abrt, fn_0);
+pub unsafe extern "C" fn Signal_RemoveHandlerAll(handler: SignalHandler) {
+    Signal_RemoveHandler(Signal_Int, handler);
+    Signal_RemoveHandler(Signal_Ill, handler);
+    Signal_RemoveHandler(Signal_Fpe, handler);
+    Signal_RemoveHandler(Signal_Segv, handler);
+    Signal_RemoveHandler(Signal_Term, handler);
+    Signal_RemoveHandler(Signal_Abrt, handler);
 }
 
 #[no_mangle]
 pub extern "C" fn Signal_ToString(this: Signal) -> *const libc::c_char {
     match this {
-        2 => return c_str!("Interrupt"),
-        4 => return c_str!("Illegal Instruction"),
-        8 => return c_str!("FP Exception"),
-        11 => return c_str!("Memory Access Violation"),
-        15 => return c_str!("Terminate"),
-        6 => return c_str!("Abort"),
-        _ => {}
+        Signal_Int => return c_str!("Interrupt"),
+        Signal_Ill => return c_str!("Illegal Instruction"),
+        Signal_Fpe => return c_str!("FP Exception"),
+        Signal_Segv => return c_str!("Memory Access Violation"),
+        Signal_Term => return c_str!("Terminate"),
+        Signal_Abrt => return c_str!("Abort"),
+        _ => c_str!("<unknown signal>"),
     }
-    c_str!("<unknown signal>")
 }
 
 #[no_mangle]


### PR DESCRIPTION
The previous code was using some buggy linked list which clearly wasn't adding signal handlers properly. I rewrote it properly using real Rust idioms. This fixes the crash when profiling the code by pressing F10 twice.