### PR TITLE
Add untargeted sensor display

### DIFF
--- a/script/Config/App.lua
+++ b/script/Config/App.lua
@@ -414,6 +414,11 @@ Config.gen = {
         range        = 20000,
     },
 
+    objectEmissionsDropoff = {1e8,   -- star
+                              1e6,   -- planet
+                              20000, -- station
+                              5000,  -- ship
+                             },
     objectEmissions = {
     -- STAR  PLANET  STATION  SHIP  THRUSTER PULSE  BEAM  JUMP  CLOAK
     {     5,     21,      10,   16,       0,     0,    0,    9,    -5},    --              |   1  Hz
@@ -445,7 +450,7 @@ Config.gen = {
     {    57,     68,      61,   15,       5,     0,    8,   14,    -5},    --             ||  10 THz > Bio-imaging  > Infrared
     {    66,     28,      46,   22,      12,    10,   17,   26,   -10},    --             ||  50 THz > Bio-imaging  > Infrared
     {    78,     20,      33,   51,      51,    72,   54,   70,   -30},    --             || 100 THz                > Infrared
-    {   100,     12,      29,   20,      90,    82,   89,   79,   -10},    --             || 500 THz > Visible light
+    {   100,     12,      29,   25,      90,    82,   89,   79,   -15},    --             || 500 THz > Visible light
     {    81,      3,      29,   32,      72,    41,   37,    8,   -15},    --             ||   1 PHz > Ultraviolet
     {    66,      6,      35,   19,      59,    90,    6,    0,    -5},    --             ||   5 PHz > Ultraviolet
     {    41,      1,      24,    6,      21,    21,    8,    0,     0},    --             ||  10 PHz > Ultraviolet
@@ -466,7 +471,7 @@ Config.gen = {
     {     0,      0,       0,    0,       0,     0,    0,    1,     0},    --            ||| 500 ZHz
     },
 
-    nebulaRes           = 1024, -- 2048 sometimes creates nebulae with stright-line edges
+    nebulaRes           = 2048,
 
     nAIPlayers          = 0,   -- # of AI players (who manage Economic assets)
     randomizeAIPlayers  = false,

--- a/script/Enums/EmissionEnums.lua
+++ b/script/Enums/EmissionEnums.lua
@@ -11,4 +11,5 @@ Enums.Emitters = {
     Pulse    = 6,
     Beam     = 7,
     Jump     = 8,
+    Cloak    = 9,
 }

--- a/script/GameObjects/Actions/Think.lua
+++ b/script/GameObjects/Actions/Think.lua
@@ -140,7 +140,6 @@ function Think:manageAsset(asset)
         -- No more jobs available; send asset to nearest station to sleep
         -- TODO: Make sure this is only done at the AI player's direction for ECONOMIC ships (miners and transports)!
         local system = asset.parent
-
         local stations = system:getStationsByDistance(asset)
         if #stations > 0 and stations[1] ~= nil then
             local station = stations[1].stationRef

--- a/script/Systems/Overlay/HUD.lua
+++ b/script/Systems/Overlay/HUD.lua
@@ -854,70 +854,191 @@ function HUD:drawSensors(a)
         UI.DrawEx.Rect(xleft, ybottom, xlength, 4, Config.ui.color.meterBarDark)
 
         -- Draw sensor bars
+        -- TODO: Convert "active" sensor dropoff ranges into passive emission strengths
         local player = self.player
         local playerShip = player:getControlling()
         local playerTarget = playerShip:getTarget()
-        if playerTarget and not playerTarget:isDestroyed() then
-            local dropoffDist = 0
-            local emType = Enums.Emitters.None
-            local targetType = playerTarget:getType()
-            if     targetType == Config:getObjectTypeByName("object_types", "Star")    then
-                emType = Enums.Emitters.Star
-                dropoffDist = 1e8
-            elseif targetType == Config:getObjectTypeByName("object_types", "Planet")  then
-                emType = Enums.Emitters.Planet
-                dropoffDist = 1e5
-            elseif targetType == Config:getObjectTypeByName("object_types", "Station") then
-                emType = Enums.Emitters.Station
-                dropoffDist = 20000
-            elseif targetType == Config:getObjectTypeByName("object_types", "Ship")    then
-                emType = Enums.Emitters.Ship
-                dropoffDist = 5000
+        if playerTarget then
+            -- Draw sensor bars for currently targeted object that isn't destroyed
+            if not playerTarget:isDestroyed() then
+                local emType = Enums.Emitters.None
+                local targetType = playerTarget:getType()
+                if     targetType == Config:getObjectTypeByName("object_types", "Star")    then
+                    emType = Enums.Emitters.Star
+                elseif targetType == Config:getObjectTypeByName("object_types", "Planet")  then
+                    emType = Enums.Emitters.Planet
+                elseif targetType == Config:getObjectTypeByName("object_types", "Station") then
+                    emType = Enums.Emitters.Station
+                elseif targetType == Config:getObjectTypeByName("object_types", "Ship")    then
+                    emType = Enums.Emitters.Ship
+                end
+
+                if emType ~= Enums.Emitters.None then
+                    local rng = RNG.FromTime()
+                    local dropoffDist = Config.gen.objectEmissionsDropoff[emType]
+
+                    -- Get the distance from the player's ship to the object
+                    local distance = playerShip:getDistance(playerTarget)
+
+                    -- Get a number from 0 - 1 describing how directly the player's ship is looking at an object
+                    local align = max(0, (playerTarget:getPos() - playerShip:getPos()):normalize():dot(playerShip:getForward()))
+
+                    -- Calculate signal dropoff as it reaches the player's ship's sensors
+                    -- Reduce the strength of the signal itself based on distance (no need to go inverse-square for unnecessary "realism" here)
+                    -- Reduce the strength of the received signal based on alignment of the sensor cone with the object
+                    -- TODO: Modify strength & accuracy of received signal based on number & quality of ship's Sensor components
+                    local dropoff = align * align * (1 - min(dropoffDist, distance) / dropoffDist)
+
+                    local barTweakVals = false
+                    deltaSensorsTimer = deltaSensorsTimer + deltaTime
+                    if deltaSensorsTimer > updateSensorsInterval then
+                        -- Update jitter
+                        barTweakVals = true
+                        deltaSensorsTimer = 0
+                    end
+
+                    for i = 1, barCount do
+                        if barTweakVals then
+                            -- Add some jitter to the sensor bars
+                            barTweak = rng:getUniformRange(-5, 5)
+                        end
+
+                        local barHeightUp   = min(barBase,    floor(Config.gen.objectEmissions[i][emType] * (barBase    + barTweak) * dropoff / 100))
+                        local barHeightDown = min(barReflect, floor(Config.gen.objectEmissions[i][emType] * (barReflect + barTweak) * dropoff / 100))
+
+                        UI.DrawEx.Rect(xleft + ((i - 1) * (barWidth + 1)),
+                                       ybottom - barHeightUp,
+                                       barWidth,
+                                       barHeightUp,
+                                       Config.ui.color.meterBarBright)
+                        UI.DrawEx.Rect(xleft + ((i - 1) * (barWidth + 1)),
+                                       ybottom,
+                                       barWidth,
+                                       barHeightDown,
+                                       Config.ui.color.meterBarDark)
+                    end
+                end
             end
+        else
+            -- Draw sensor bars for all objects in "cone" projected
+            local rng = RNG.FromTime()
+            local system = playerShip.parent
+            if not playerShip:isShipDocked() and system then -- no displaying Sensor readings while docked at a space station!
+                local stars    = system:getStars()
+                local planets  = system:getPlanets()
+                local stations = system:getStations()
+                local ships    = system:getShips()
+                local objects       = {}
+                local barHeightUp   = {}
+                local barHeightDown = {}
 
-            if emType ~= Enums.Emitters.None then
-                local rng = RNG.FromTime()
+                for _, star in ipairs(stars) do
+                    if playerShip:getDistance(star) <= Config.gen.objectEmissionsDropoff[Enums.Emitters.Star] then
+                        local align = max(0, (star:getPos() - playerShip:getPos()):normalize():dot(playerShip:getForward()))
+                        if align * align >= 0.3 then
+                            insert(objects, star)
+                        end
+                    end
+                end
+                for _, planet in ipairs(planets) do
+                    if playerShip:getDistance(planet) <= Config.gen.objectEmissionsDropoff[Enums.Emitters.Planet] then
+                        local align = max(0, (planet:getPos() - playerShip:getPos()):normalize():dot(playerShip:getForward()))
+                        if align * align >= 0.3 then
+                            insert(objects, planet)
+                        end
+                    end
+                end
+                for _, station in ipairs(stations) do
+                    if not station:isDestroyed() and playerShip:getDistance(station) <= Config.gen.objectEmissionsDropoff[Enums.Emitters.Station] then
+                        local align = max(0, (station:getPos() - playerShip:getPos()):normalize():dot(playerShip:getForward()))
+                        if align * align >= 0.3 then
+                            insert(objects, station)
+                        end
+                    end
+                end
+                for _, ship in ipairs(ships) do
+                    if ship ~= playerShip and
+                      not ship:isDestroyed() and
+                      playerShip:getDistance(ship) <= Config.gen.objectEmissionsDropoff[Enums.Emitters.Ship] then
+                        local align = max(0, (ship:getPos() - playerShip:getPos()):normalize():dot(playerShip:getForward()))
+                        if align * align >= 0.3 then
+                            insert(objects, ship)
+                        end
+                    end
+                end
 
-                -- Get the distance from the player's ship to the object
-                local distance = playerShip:getDistance(playerTarget)
-
-                -- Get a number from 0 - 1 describing how directly the player's ship is looking at an object
-                local align = max(0, (playerTarget:getPos() - playerShip:getPos()):normalize():dot(playerShip:getForward()))
-
-                -- Calculate signal dropoff as it reaches the player's ship's sensors
-                -- Reduce the strength of the signal itself based on distance (no need to go inverse-square for unnecessary "realism" here)
-                -- Reduce the strength of the received signal based on alignment of the sensor cone with the object
-                -- TODO: Degrade the accuracy of the signal in particular frequency bands based on number/quality of ship's Sensor components
-                local dropoff = align * align * (1 - min(dropoffDist, distance) / dropoffDist)
-
-                local color = Config.ui.color.meterBarLight
-
+                -- Check to see if we should update visual jitter this pass
                 local barTweakVals = false
                 deltaSensorsTimer = deltaSensorsTimer + deltaTime
                 if deltaSensorsTimer > updateSensorsInterval then
-                    -- Update jitter
+                    -- Yes, update jitter this pass
                     barTweakVals = true
                     deltaSensorsTimer = 0
                 end
 
+                -- Initialize sensor bar values for this pass
+                for i = 1, barCount do
+                    barHeightUp[i]   = 0
+                    barHeightDown[i] = 0
+                end
+
+                -- Loop through all object close enough and in the sensor cone
+                -- Sum up all their values in each frequency band modified by distance and by dropoff from the cone's center
+                -- Multiply these values by the max onscreen size of the up/down bars to get each bar's height in pixels
+                for _, object in ipairs(objects) do
+                    local emType = Enums.Emitters.None
+                    local targetType = object:getType()
+                    if     targetType == Config:getObjectTypeByName("object_types", "Star")    then
+                        emType = Enums.Emitters.Star
+                    elseif targetType == Config:getObjectTypeByName("object_types", "Planet")  then
+                        emType = Enums.Emitters.Planet
+                    elseif targetType == Config:getObjectTypeByName("object_types", "Station") then
+                        emType = Enums.Emitters.Station
+                    elseif targetType == Config:getObjectTypeByName("object_types", "Ship")    then
+                        emType = Enums.Emitters.Ship
+                    end
+
+                    local dropoffDist = Config.gen.objectEmissionsDropoff[emType]
+
+                    -- Get the distance from the player's ship to the object
+                    local distance = playerShip:getDistance(object)
+
+                    -- Get a number from 0 - 1 describing how directly the player's ship is looking at an object
+                    local align = max(0, (object:getPos() - playerShip:getPos()):normalize():dot(playerShip:getForward()))
+
+                    -- Calculate signal dropoff as it reaches the player's ship's sensors
+                    -- Reduce the strength of the signal itself based on distance (no need to go inverse-square for unnecessary "realism" here)
+                    -- Reduce the strength of the received signal based on alignment of the sensor cone with the object
+                    -- TODO: Modify strength & accuracy of received signal based on number & quality of ship's Sensor components
+                    local dropoff = align * align * (1 - min(dropoffDist, distance) / dropoffDist)
+
+                    for i = 1, barCount do
+                        barHeightUp[i]   = barHeightUp[i]   + Config.gen.objectEmissions[i][emType] * barBase    * dropoff / 100
+                        barHeightDown[i] = barHeightDown[i] + Config.gen.objectEmissions[i][emType] * barReflect * dropoff / 100
+                    end
+                end
+
+                -- Display each sensor frequency bar
                 for i = 1, barCount do
                     if barTweakVals then
                         -- Add some jitter to the sensor bars
                         barTweak = rng:getUniformRange(-5, 5)
                     end
 
-                    local barHeightUp   = min(barBase,    floor(Config.gen.objectEmissions[i][emType] * (barBase    + barTweak) * dropoff / 100))
-                    local barHeightDown = min(barReflect, floor(Config.gen.objectEmissions[i][emType] * (barReflect + barTweak) * dropoff / 100))
+                    -- Add jitter constrained by the max height of the up and down (reflection) bars
+                    local barHeightU = min(barBase,    barHeightUp[i]   + barTweak)
+                    local barHeightD = min(barReflect, barHeightDown[i] + barTweak)
 
+                    -- Finally, actually display all the sensor frequency bars
                     UI.DrawEx.Rect(xleft + ((i - 1) * (barWidth + 1)),
-                                   ybottom - barHeightUp,
+                                   ybottom - barHeightU,
                                    barWidth,
-                                   barHeightUp,
+                                   barHeightU,
                                    Config.ui.color.meterBarBright)
                     UI.DrawEx.Rect(xleft + ((i - 1) * (barWidth + 1)),
                                    ybottom,
                                    barWidth,
-                                   barHeightDown,
+                                   barHeightD,
                                    Config.ui.color.meterBarDark)
                 end
             end


### PR DESCRIPTION
* The player ship's sensors now have two modes: 1) display frequency info about a targeted object (if within range and inside the sensor cone), and 2) display frequency info for all objects in range and inside the sensor cone.
* System.lua got a minor update to add object lists for Stars (not yet implemented) and Planets; to provide helper functions for returning System object lists; and to slightly rearrange the ordering of helper function definitions to be a bit more logical.