### PR TITLE
Remove warnings after updating to Rust 1.74

### DIFF
--- a/engine/lib/luajit-ffi-gen/src/args/bind_args.rs
+++ b/engine/lib/luajit-ffi-gen/src/args/bind_args.rs
@@ -49,7 +49,9 @@ impl BindArgs {
     /// If true then the function return string representation of the object.
     /// 'tostring' binding will be added to the metatype section of the Lua FFI file.
     pub fn is_to_string(&self) -> bool {
-        let Some(ty) = self.role else { return false; };
+        let Some(ty) = self.role else {
+            return false;
+        };
 
         ty == BindMethodRole::ToString
     }

--- a/engine/lib/luajit-ffi-gen/src/impl_item/parse.rs
+++ b/engine/lib/luajit-ffi-gen/src/impl_item/parse.rs
@@ -53,10 +53,7 @@ fn get_path_last_name(path: &Path) -> Result<String> {
 
 fn get_path_last_name_with_generics(path: &Path) -> Result<(String, Vec<Type>)> {
     let Some(last_seg) = path.segments.last() else {
-        return Err(Error::new(
-            path.span(),
-            "expected a type identifier",
-        ));
+        return Err(Error::new(path.span(), "expected a type identifier"));
     };
 
     let generic_types = if let PathArguments::AngleBracketed(generic_args) = &last_seg.arguments {

--- a/engine/lib/phx/src/input/input_bindings.rs
+++ b/engine/lib/phx/src/input/input_bindings.rs
@@ -69,7 +69,6 @@ pub struct AggregateButton {
     pub onDown: LuaRef,
     pub onReleased: LuaRef,
 }
-pub type State = i32;
 
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/engine/lib/phx/src/lua/lua_scheduler.rs
+++ b/engine/lib/phx/src/lua/lua_scheduler.rs
@@ -16,12 +16,6 @@ extern "C" {
     fn Lua_SetFn(_: *mut Lua, name: *const libc::c_char, _: LuaFn);
 }
 
-pub type LuaNumber = f64;
-pub type LuaInteger = libc::ptrdiff_t;
-pub type Lua = lua_State;
-pub type LuaFn = Option<unsafe extern "C" fn(*mut Lua) -> i32>;
-pub type LuaRef = LuaInteger;
-
 #[derive(Clone)]
 #[repr(C)]
 pub struct Scheduler {

--- a/engine/lib/phx/src/math/rng.rs
+++ b/engine/lib/phx/src/math/rng.rs
@@ -10,15 +10,6 @@ pub struct Rng {
     pub state: [u64; 2],
 }
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Quat {
-    pub x: f32,
-    pub y: f32,
-    pub z: f32,
-    pub w: f32,
-}
-
 #[inline]
 unsafe extern "C" fn Random_SplitMix64(state: *mut u64) -> u64 {
     *state = (*state as u64).wrapping_add(0x9e3779b97f4a7c15);

--- a/engine/lib/phx/src/physics/physics.rs
+++ b/engine/lib/phx/src/physics/physics.rs
@@ -25,17 +25,15 @@ PHX_API void      _cppPhysics_DrawWireframes          (Physics*);
 
  */
 
+use super::*;
 use crate::math::*;
 
 extern "C" {
     pub type Physics;
-    pub type RigidBody;
-    pub type Trigger;
     pub type Collision;
     pub type Sphere;
     pub type RayCastResult;
     pub type ShapeCastResult;
-    pub type Quat;
     fn _cppPhysics_Create() -> *mut Physics;
     fn _cppPhysics_Free(_: *mut Physics);
     fn _cppPhysics_AddRigidBody(_: *mut Physics, _: *mut RigidBody);

--- a/engine/lib/phx/src/physics/rigid_body.rs
+++ b/engine/lib/phx/src/physics/rigid_body.rs
@@ -50,19 +50,17 @@ PHX_API void        _cppRigidBody_SetScale                     (RigidBody*, floa
 
 */
 
-use crate::math::Vec3;
+use crate::math::*;
+use crate::render::*;
 
 extern "C" {
     pub type RigidBody;
-    pub type Mesh;
-    pub type Quat;
-    pub type Box3;
-    pub type Matrix;
+    pub type _Mesh; // Opaque mesh type to squash the warnings, as mesh::Mesh is not FFI safe, but it doesn't matter.
     fn _cppRigidBody_CreateBox() -> *mut RigidBody;
-    fn _cppRigidBody_CreateBoxFromMesh(mesh: *mut Mesh) -> *mut RigidBody;
+    fn _cppRigidBody_CreateBoxFromMesh(mesh: *mut _Mesh) -> *mut RigidBody;
     fn _cppRigidBody_CreateSphere() -> *mut RigidBody;
-    fn _cppRigidBody_CreateSphereFromMesh(mesh: *mut Mesh) -> *mut RigidBody;
-    fn _cppRigidBody_CreateHullFromMesh(mesh: *mut Mesh) -> *mut RigidBody;
+    fn _cppRigidBody_CreateSphereFromMesh(mesh: *mut _Mesh) -> *mut RigidBody;
+    fn _cppRigidBody_CreateHullFromMesh(mesh: *mut _Mesh) -> *mut RigidBody;
     fn _cppRigidBody_Free(this: &mut RigidBody);
     fn _cppRigidBody_ApplyForce(this: &mut RigidBody, force: *mut Vec3);
     fn _cppRigidBody_ApplyTorque(this: &mut RigidBody, torque: *mut Vec3);
@@ -113,7 +111,7 @@ pub unsafe extern "C" fn RigidBody_CreateBox() -> *mut RigidBody {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn RigidBody_CreateBoxFromMesh(mesh: *mut Mesh) -> *mut RigidBody {
+pub unsafe extern "C" fn RigidBody_CreateBoxFromMesh(mesh: *mut _Mesh) -> *mut RigidBody {
     _cppRigidBody_CreateBoxFromMesh(mesh)
 }
 
@@ -123,12 +121,12 @@ pub unsafe extern "C" fn RigidBody_CreateSphere() -> *mut RigidBody {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn RigidBody_CreateSphereFromMesh(mesh: *mut Mesh) -> *mut RigidBody {
+pub unsafe extern "C" fn RigidBody_CreateSphereFromMesh(mesh: *mut _Mesh) -> *mut RigidBody {
     _cppRigidBody_CreateSphereFromMesh(mesh)
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn RigidBody_CreateHullFromMesh(mesh: *mut Mesh) -> *mut RigidBody {
+pub unsafe extern "C" fn RigidBody_CreateHullFromMesh(mesh: *mut _Mesh) -> *mut RigidBody {
     _cppRigidBody_CreateHullFromMesh(mesh)
 }
 

--- a/engine/lib/phx/src/physics/trigger.rs
+++ b/engine/lib/phx/src/physics/trigger.rs
@@ -16,12 +16,11 @@ PHX_API void        _cppTrigger_SetPosLocal       (Trigger*, Vec3f*);
 
  */
 
-use crate::math::Vec3;
+use super::*;
+use crate::math::*;
 
 extern "C" {
     pub type Trigger;
-    pub type RigidBody;
-    pub type Box3;
     fn _cppTrigger_CreateBox(halfExtents: *mut Vec3) -> *mut Trigger;
     fn _cppTrigger_Free(this: &mut Trigger);
     fn _cppTrigger_Attach(this: &mut Trigger, rb: *mut RigidBody, offset: *mut Vec3);

--- a/engine/lib/phx/src/system/profiler.rs
+++ b/engine/lib/phx/src/system/profiler.rs
@@ -9,9 +9,6 @@ use crate::*;
 use std::cmp::Ordering;
 use std::io::{self, Write};
 
-pub type Signal = i32;
-// pub type SignalHandler = Option<extern "C" fn(Signal) -> ()>;
-
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Scope {

--- a/engine/lib/phx/src/system/str_map.rs
+++ b/engine/lib/phx/src/system/str_map.rs
@@ -11,14 +11,14 @@ use crate::*;
 pub struct StrMap {
     pub capacity: u32,
     pub size: u32,
-    pub data: *mut Node,
+    pub data: *mut StrMapNode,
 }
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct Node {
+pub struct StrMapNode {
     pub key: *const libc::c_char,
-    pub next: *mut Node,
+    pub next: *mut StrMapNode,
     pub value: *mut libc::c_void,
 }
 
@@ -26,7 +26,7 @@ pub struct Node {
 #[repr(C)]
 pub struct StrMapIter {
     pub map: *mut StrMap,
-    pub node: *mut Node,
+    pub node: *mut StrMapNode,
     pub slot: u32,
 }
 
@@ -36,7 +36,10 @@ unsafe extern "C" fn Hash(key: *const libc::c_char) -> u64 {
 }
 
 #[inline]
-unsafe extern "C" fn StrMap_GetBucket(this: &mut StrMap, key: *const libc::c_char) -> *mut Node {
+unsafe extern "C" fn StrMap_GetBucket(
+    this: &mut StrMap,
+    key: *const libc::c_char,
+) -> *mut StrMapNode {
     (this.data).offset((Hash(key)).wrapping_rem(this.capacity as u64) as isize)
 }
 
@@ -46,16 +49,16 @@ unsafe extern "C" fn StrMap_Grow(this: &mut StrMap) {
         size: 0,
         data: std::ptr::null_mut(),
     };
-    newMap.data = MemNewArrayZero!(Node, newMap.capacity);
+    newMap.data = MemNewArrayZero!(StrMapNode, newMap.capacity);
     let mut i: u32 = 0;
     while i < this.capacity {
-        let mut node: *mut Node = (this.data).offset(i as isize);
+        let mut node: *mut StrMapNode = (this.data).offset(i as isize);
         if !((*node).key).is_null() {
             StrMap_Set(&mut newMap, (*node).key, (*node).value);
             StrFree((*node).key);
             node = (*node).next;
             while !node.is_null() {
-                let next: *mut Node = (*node).next;
+                let next: *mut StrMapNode = (*node).next;
                 StrMap_Set(&mut newMap, (*node).key, (*node).value);
                 StrFree((*node).key);
                 MemFree(node as *const _);
@@ -72,7 +75,7 @@ unsafe extern "C" fn StrMap_Grow(this: &mut StrMap) {
 pub unsafe extern "C" fn StrMap_Create(capacity: u32) -> *mut StrMap {
     let this = MemNewZero!(StrMap);
     (*this).capacity = capacity;
-    (*this).data = MemNewArrayZero!(Node, capacity);
+    (*this).data = MemNewArrayZero!(StrMapNode, capacity);
     this
 }
 
@@ -80,12 +83,12 @@ pub unsafe extern "C" fn StrMap_Create(capacity: u32) -> *mut StrMap {
 pub unsafe extern "C" fn StrMap_Free(this: *mut StrMap) {
     let mut i: u32 = 0;
     while i < (*this).capacity {
-        let mut node: *mut Node = ((*this).data).offset(i as isize);
+        let mut node: *mut StrMapNode = ((*this).data).offset(i as isize);
         if !((*node).key).is_null() {
             StrFree((*node).key);
             node = (*node).next;
             while !node.is_null() {
-                let next: *mut Node = (*node).next;
+                let next: *mut StrMapNode = (*node).next;
                 StrFree((*node).key);
                 MemFree(node as *const _);
                 node = next;
@@ -104,13 +107,13 @@ pub unsafe extern "C" fn StrMap_FreeEx(
 ) {
     let mut i: u32 = 0;
     while i < (*this).capacity {
-        let mut node: *mut Node = ((*this).data).offset(i as isize);
+        let mut node: *mut StrMapNode = ((*this).data).offset(i as isize);
         if !((*node).key).is_null() {
             freeFn.expect("non-null function pointer")((*node).key, (*node).value);
             StrFree((*node).key);
             node = (*node).next;
             while !node.is_null() {
-                let next: *mut Node = (*node).next;
+                let next: *mut StrMapNode = (*node).next;
                 freeFn.expect("non-null function pointer")((*node).key, (*node).value);
                 StrFree((*node).key);
                 MemFree(node as *const _);
@@ -128,7 +131,7 @@ pub unsafe extern "C" fn StrMap_Get(
     this: &mut StrMap,
     key: *const libc::c_char,
 ) -> *mut libc::c_void {
-    let mut node: *mut Node = StrMap_GetBucket(this, key);
+    let mut node: *mut StrMapNode = StrMap_GetBucket(this, key);
     if ((*node).key).is_null() {
         return std::ptr::null_mut();
     }
@@ -148,12 +151,12 @@ pub extern "C" fn StrMap_GetSize(this: &mut StrMap) -> u32 {
 
 #[no_mangle]
 pub unsafe extern "C" fn StrMap_Remove(this: &mut StrMap, key: *const libc::c_char) {
-    let mut prev: *mut *mut Node = std::ptr::null_mut();
-    let mut node: *mut Node = StrMap_GetBucket(this, key);
+    let mut prev: *mut *mut StrMapNode = std::ptr::null_mut();
+    let mut node: *mut StrMapNode = StrMap_GetBucket(this, key);
     while !node.is_null() && !((*node).key).is_null() {
         if (*node).key.as_str() == key.as_str() {
             StrFree((*node).key);
-            let next: *mut Node = (*node).next;
+            let next: *mut StrMapNode = (*node).next;
             if !next.is_null() {
                 (*node).key = (*next).key;
                 (*node).next = (*next).next;
@@ -187,13 +190,13 @@ pub unsafe extern "C" fn StrMap_Set(
     if (3_u32).wrapping_mul(this.capacity) < (4_u32).wrapping_mul(this.size) {
         StrMap_Grow(this);
     }
-    let mut node: *mut Node = StrMap_GetBucket(this, key);
+    let mut node: *mut StrMapNode = StrMap_GetBucket(this, key);
     if ((*node).key).is_null() {
         (*node).key = StrDup(key);
         (*node).value = value;
         return;
     }
-    let mut prev: *mut *mut Node = std::ptr::null_mut();
+    let mut prev: *mut *mut StrMapNode = std::ptr::null_mut();
     while !node.is_null() {
         if (*node).key.as_str() == key.as_str() {
             (*node).value = value;
@@ -202,7 +205,7 @@ pub unsafe extern "C" fn StrMap_Set(
         prev = &mut (*node).next;
         node = (*node).next;
     }
-    node = MemNew!(Node);
+    node = MemNew!(StrMapNode);
     (*node).key = StrDup(key);
     (*node).value = value;
     (*node).next = std::ptr::null_mut();
@@ -222,7 +225,7 @@ pub unsafe extern "C" fn StrMap_Dump(this: &mut StrMap) {
 
     let mut i: u32 = 0;
     while i < this.capacity {
-        let mut node: *mut Node = (this.data).offset(i as isize);
+        let mut node: *mut StrMapNode = (this.data).offset(i as isize);
         if !((*node).key).is_null() {
             info!("  [{i:03}]:");
             while !node.is_null() {
@@ -247,7 +250,7 @@ pub unsafe extern "C" fn StrMap_Iterate(this: &mut StrMap) -> *mut StrMapIter {
     (*it).node = std::ptr::null_mut();
     let mut i: u32 = 0;
     while i < this.capacity {
-        let node: *mut Node = (this.data).offset(i as isize);
+        let node: *mut StrMapNode = (this.data).offset(i as isize);
         if ((*node).key).is_null() {
             i = i.wrapping_add(1);
         } else {
@@ -274,7 +277,7 @@ pub unsafe extern "C" fn StrMapIter_Advance(it: *mut StrMapIter) {
     (*it).slot = ((*it).slot).wrapping_add(1);
     let mut i: u32 = (*it).slot;
     while i < (*this).capacity {
-        let node: *mut Node = ((*this).data).offset(i as isize);
+        let node: *mut StrMapNode = ((*this).data).offset(i as isize);
         if ((*node).key).is_null() {
             i = i.wrapping_add(1);
         } else {


### PR DESCRIPTION
The updated  Rust compiler generates a bunch of new warnings due to duplicate symbols, so this PR cleans them up.