### PR TITLE
Reimplement Matrix and Quat using glam.

### DIFF
--- a/engine/lib/luajit-ffi-gen/README.md
+++ b/engine/lib/luajit-ffi-gen/README.md
@@ -264,7 +264,7 @@ User types in method parameters position are sent by reference or mutable refere
 
 ### Option
 
-Returned as a **\*mut T**, and **None** is nterpreted as **NULL** pointer.
+Returned as a **\*mut T**, and **None** is interpreted as **NULL** pointer.
 
 ### Result
 

--- a/engine/lib/phx/src/math/box3.rs
+++ b/engine/lib/phx/src/math/box3.rs
@@ -1,0 +1,101 @@
+use super::*;
+
+#[derive(Copy, Clone, Default)]
+#[repr(C)]
+pub struct Box3 {
+    pub lower: Vec3,
+    pub upper: Vec3,
+}
+
+impl Box3 {
+    pub fn new(lower: Vec3, upper: Vec3) -> Box3 {
+        Box3 { lower, upper }
+    }
+
+    pub fn union(a: Box3, b: Box3) -> Box3 {
+        Box3 {
+            lower: Vec3 {
+                x: f32::min(a.lower.x, b.lower.x),
+                y: f32::min(a.lower.y, b.lower.y),
+                z: f32::min(a.lower.z, b.lower.z),
+            },
+            upper: Vec3 {
+                x: f32::max(a.upper.x, b.upper.x),
+                y: f32::max(a.upper.y, b.upper.y),
+                z: f32::max(a.upper.z, b.upper.z),
+            },
+        }
+    }
+
+    pub fn intersection(a: Box3, b: Box3) -> Box3 {
+        Box3 {
+            lower: Vec3 {
+                x: f32::max(a.lower.x, b.lower.x),
+                y: f32::max(a.lower.y, b.lower.y),
+                z: f32::max(a.lower.z, b.lower.z),
+            },
+            upper: Vec3 {
+                x: f32::min(a.upper.x, b.upper.x),
+                y: f32::min(a.upper.y, b.upper.y),
+                z: f32::min(a.upper.z, b.upper.z),
+            },
+        }
+    }
+
+    pub fn center(&self) -> Vec3 {
+        Vec3::new(
+            (self.lower.x + self.upper.x) / 2.0f32,
+            (self.lower.y + self.upper.y) / 2.0f32,
+            (self.lower.z + self.upper.z) / 2.0f32,
+        )
+    }
+
+    pub fn add(&mut self, point: Vec3) {
+        self.lower = Vec3::min(self.lower, point);
+        self.upper = Vec3::max(self.upper, point);
+    }
+
+    pub fn volume(&self) -> f32 {
+        (self.upper.x - self.lower.x)
+            * (self.upper.y - self.lower.y)
+            * (self.upper.z - self.lower.z)
+    }
+
+    pub fn contains(a: Box3, b: Box3) -> bool {
+        a.lower.x <= b.lower.x
+            && a.upper.x >= b.upper.x
+            && a.lower.y <= b.lower.y
+            && a.upper.y >= b.upper.y
+            && a.lower.z <= b.lower.z
+            && a.upper.z >= b.upper.z
+    }
+
+    pub fn intersects_ray(&self, ro: Vec3, rdi: Vec3) -> bool {
+        let mut t1: f64 = (rdi.x * (self.lower.x - ro.x)) as f64;
+        let mut t2: f64 = (rdi.x * (self.upper.x - ro.x)) as f64;
+        let mut tMin: f64 = f64::min(t1, t2);
+        let mut tMax: f64 = f64::max(t1, t2);
+        t1 = (rdi.y * (self.lower.y - ro.y)) as f64;
+        t2 = (rdi.y * (self.upper.y - ro.y)) as f64;
+        tMin = f64::max(tMin, f64::min(t1, t2));
+        tMax = f64::min(tMax, f64::max(t1, t2));
+        t1 = (rdi.z * (self.lower.z - ro.z)) as f64;
+        t2 = (rdi.z * (self.upper.z - ro.z)) as f64;
+        tMin = f64::max(tMin, f64::min(t1, t2));
+        tMax = f64::min(tMax, f64::max(t1, t2));
+        tMax >= tMin && tMax > 0.0
+    }
+
+    pub fn intersects_box(a: Box3, b: Box3) -> bool {
+        if a.lower.x > b.upper.x || a.upper.x < b.lower.x {
+            return false;
+        }
+        if a.lower.y > b.upper.y || a.upper.y < b.lower.y {
+            return false;
+        }
+        if a.lower.z > b.upper.z || a.upper.z < b.lower.z {
+            return false;
+        }
+        true
+    }
+}

--- a/engine/lib/phx/src/math/math.rs
+++ b/engine/lib/phx/src/math/math.rs
@@ -7,106 +7,6 @@ pub use glam::{DVec2, DVec3, DVec4};
 pub use glam::{IVec2, IVec3, IVec4};
 pub use glam::{Vec2, Vec3, Vec4};
 
-#[derive(Copy, Clone, Default)]
-#[repr(C)]
-pub struct Box3 {
-    pub lower: Vec3,
-    pub upper: Vec3,
-}
-
-impl Box3 {
-    pub fn new(lower: Vec3, upper: Vec3) -> Box3 {
-        Box3 { lower, upper }
-    }
-
-    pub fn union(a: Box3, b: Box3) -> Box3 {
-        Box3 {
-            lower: Vec3 {
-                x: f32::min(a.lower.x, b.lower.x),
-                y: f32::min(a.lower.y, b.lower.y),
-                z: f32::min(a.lower.z, b.lower.z),
-            },
-            upper: Vec3 {
-                x: f32::max(a.upper.x, b.upper.x),
-                y: f32::max(a.upper.y, b.upper.y),
-                z: f32::max(a.upper.z, b.upper.z),
-            },
-        }
-    }
-
-    pub fn intersection(a: Box3, b: Box3) -> Box3 {
-        Box3 {
-            lower: Vec3 {
-                x: f32::max(a.lower.x, b.lower.x),
-                y: f32::max(a.lower.y, b.lower.y),
-                z: f32::max(a.lower.z, b.lower.z),
-            },
-            upper: Vec3 {
-                x: f32::min(a.upper.x, b.upper.x),
-                y: f32::min(a.upper.y, b.upper.y),
-                z: f32::min(a.upper.z, b.upper.z),
-            },
-        }
-    }
-
-    pub fn center(&self) -> Vec3 {
-        Vec3::new(
-            (self.lower.x + self.upper.x) / 2.0f32,
-            (self.lower.y + self.upper.y) / 2.0f32,
-            (self.lower.z + self.upper.z) / 2.0f32,
-        )
-    }
-
-    pub fn add(&mut self, point: Vec3) {
-        self.lower = Vec3::min(self.lower, point);
-        self.upper = Vec3::max(self.upper, point);
-    }
-
-    pub fn volume(&self) -> f32 {
-        (self.upper.x - self.lower.x)
-            * (self.upper.y - self.lower.y)
-            * (self.upper.z - self.lower.z)
-    }
-
-    pub fn contains(a: Box3, b: Box3) -> bool {
-        a.lower.x <= b.lower.x
-            && a.upper.x >= b.upper.x
-            && a.lower.y <= b.lower.y
-            && a.upper.y >= b.upper.y
-            && a.lower.z <= b.lower.z
-            && a.upper.z >= b.upper.z
-    }
-
-    pub fn intersects_ray(&self, ro: Vec3, rdi: Vec3) -> bool {
-        let mut t1: f64 = (rdi.x * (self.lower.x - ro.x)) as f64;
-        let mut t2: f64 = (rdi.x * (self.upper.x - ro.x)) as f64;
-        let mut tMin: f64 = f64::min(t1, t2);
-        let mut tMax: f64 = f64::max(t1, t2);
-        t1 = (rdi.y * (self.lower.y - ro.y)) as f64;
-        t2 = (rdi.y * (self.upper.y - ro.y)) as f64;
-        tMin = f64::max(tMin, f64::min(t1, t2));
-        tMax = f64::min(tMax, f64::max(t1, t2));
-        t1 = (rdi.z * (self.lower.z - ro.z)) as f64;
-        t2 = (rdi.z * (self.upper.z - ro.z)) as f64;
-        tMin = f64::max(tMin, f64::min(t1, t2));
-        tMax = f64::min(tMax, f64::max(t1, t2));
-        tMax >= tMin && tMax > 0.0
-    }
-
-    pub fn intersects_box(a: Box3, b: Box3) -> bool {
-        if a.lower.x > b.upper.x || a.upper.x < b.lower.x {
-            return false;
-        }
-        if a.lower.y > b.upper.y || a.upper.y < b.lower.y {
-            return false;
-        }
-        if a.lower.z > b.upper.z || a.upper.z < b.lower.z {
-            return false;
-        }
-        true
-    }
-}
-
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Sphere {
@@ -143,6 +43,16 @@ pub extern "C" fn Float_Validatef(x: f32) -> Error {
         }
     }
     0 as Error
+}
+
+#[inline]
+pub extern "C" fn Float_ApproximatelyEqual(x: f64, y: f64) -> bool {
+    f64::abs(x - y) < 1e-3
+}
+
+#[inline]
+pub extern "C" fn Float_ApproximatelyEqualf(x: f32, y: f32) -> bool {
+    f32::abs(x - y) < 1e-3
 }
 
 #[inline]

--- a/engine/lib/phx/src/math/matrix.rs
+++ b/engine/lib/phx/src/math/matrix.rs
@@ -4,42 +4,34 @@ use crate::common::*;
 use crate::internal::*;
 use crate::math::*;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Matrix {
-    pub m: [f32; 16],
+pub use glam::{Mat3, Mat4};
+
+// glam::Mat4 is a column-major matrix.
+pub type Matrix = Mat4;
+
+pub trait MatrixExtensions {
+    fn get_forward(&self) -> Vec3;
+    fn get_right(&self) -> Vec3;
+    fn get_up(&self) -> Vec3;
+    fn get_translation(&self) -> Vec3;
 }
 
-impl Matrix {
-    pub fn to_string(&self) -> String {
-        format!(
-            "[{:+.2}, {:+.2}, {:+.2}, {:+.2}]\n\
-                [{:+.2}, {:+.2}, {:+.2}, {:+.2}]\n\
-                [{:+.2}, {:+.2}, {:+.2}, {:+.2}]\n\
-                [{:+.2}, {:+.2}, {:+.2}, {:+.2}]",
-            self.m[0],
-            self.m[1],
-            self.m[2],
-            self.m[3],
-            self.m[4],
-            self.m[5],
-            self.m[6],
-            self.m[7],
-            self.m[8],
-            self.m[9],
-            self.m[10],
-            self.m[11],
-            self.m[12],
-            self.m[13],
-            self.m[14],
-            self.m[15],
-        )
+impl MatrixExtensions for Matrix {
+    fn get_forward(&self) -> Vec3 {
+        -self.z_axis.truncate()
     }
-}
 
-#[inline]
-extern "C" fn Float_ApproximatelyEqual(x: f64, y: f64) -> bool {
-    f64::abs(x - y) < 1e-3f64
+    fn get_right(&self) -> Vec3 {
+        self.x_axis.truncate()
+    }
+
+    fn get_up(&self) -> Vec3 {
+        self.y_axis.truncate()
+    }
+
+    fn get_translation(&self) -> Vec3 {
+        self.w_axis.truncate()
+    }
 }
 
 #[no_mangle]
@@ -50,366 +42,122 @@ pub extern "C" fn Matrix_Clone(this: &Matrix) -> Box<Matrix> {
 #[no_mangle]
 pub extern "C" fn Matrix_Free(_: Option<Box<Matrix>>) {}
 
-unsafe extern "C" fn Matrix_IOInverse(in_0: &Matrix, out: &mut Matrix) {
-    let src: *const f32 = in_0 as *const Matrix as *const f32;
-    let dst: *mut f32 = out as *mut Matrix as *mut f32;
-    *dst.offset(0) = *src.offset(5) * *src.offset(10) * *src.offset(15)
-        - *src.offset(5) * *src.offset(11) * *src.offset(14)
-        - *src.offset(9) * *src.offset(6) * *src.offset(15)
-        + *src.offset(9) * *src.offset(7) * *src.offset(14)
-        + *src.offset(13) * *src.offset(6) * *src.offset(11)
-        - *src.offset(13) * *src.offset(7) * *src.offset(10);
-    *dst.offset(4) = -*src.offset(4) * *src.offset(10) * *src.offset(15)
-        + *src.offset(4) * *src.offset(11) * *src.offset(14)
-        + *src.offset(8) * *src.offset(6) * *src.offset(15)
-        - *src.offset(8) * *src.offset(7) * *src.offset(14)
-        - *src.offset(12) * *src.offset(6) * *src.offset(11)
-        + *src.offset(12) * *src.offset(7) * *src.offset(10);
-    *dst.offset(8) = *src.offset(4) * *src.offset(9) * *src.offset(15)
-        - *src.offset(4) * *src.offset(11) * *src.offset(13)
-        - *src.offset(8) * *src.offset(5) * *src.offset(15)
-        + *src.offset(8) * *src.offset(7) * *src.offset(13)
-        + *src.offset(12) * *src.offset(5) * *src.offset(11)
-        - *src.offset(12) * *src.offset(7) * *src.offset(9);
-    *dst.offset(12) = -*src.offset(4) * *src.offset(9) * *src.offset(14)
-        + *src.offset(4) * *src.offset(10) * *src.offset(13)
-        + *src.offset(8) * *src.offset(5) * *src.offset(14)
-        - *src.offset(8) * *src.offset(6) * *src.offset(13)
-        - *src.offset(12) * *src.offset(5) * *src.offset(10)
-        + *src.offset(12) * *src.offset(6) * *src.offset(9);
-    *dst.offset(1) = -*src.offset(1) * *src.offset(10) * *src.offset(15)
-        + *src.offset(1) * *src.offset(11) * *src.offset(14)
-        + *src.offset(9) * *src.offset(2) * *src.offset(15)
-        - *src.offset(9) * *src.offset(3) * *src.offset(14)
-        - *src.offset(13) * *src.offset(2) * *src.offset(11)
-        + *src.offset(13) * *src.offset(3) * *src.offset(10);
-    *dst.offset(5) = *src.offset(0) * *src.offset(10) * *src.offset(15)
-        - *src.offset(0) * *src.offset(11) * *src.offset(14)
-        - *src.offset(8) * *src.offset(2) * *src.offset(15)
-        + *src.offset(8) * *src.offset(3) * *src.offset(14)
-        + *src.offset(12) * *src.offset(2) * *src.offset(11)
-        - *src.offset(12) * *src.offset(3) * *src.offset(10);
-    *dst.offset(9) = -*src.offset(0) * *src.offset(9) * *src.offset(15)
-        + *src.offset(0) * *src.offset(11) * *src.offset(13)
-        + *src.offset(8) * *src.offset(1) * *src.offset(15)
-        - *src.offset(8) * *src.offset(3) * *src.offset(13)
-        - *src.offset(12) * *src.offset(1) * *src.offset(11)
-        + *src.offset(12) * *src.offset(3) * *src.offset(9);
-    *dst.offset(13) = *src.offset(0) * *src.offset(9) * *src.offset(14)
-        - *src.offset(0) * *src.offset(10) * *src.offset(13)
-        - *src.offset(8) * *src.offset(1) * *src.offset(14)
-        + *src.offset(8) * *src.offset(2) * *src.offset(13)
-        + *src.offset(12) * *src.offset(1) * *src.offset(10)
-        - *src.offset(12) * *src.offset(2) * *src.offset(9);
-    *dst.offset(2) = *src.offset(1) * *src.offset(6) * *src.offset(15)
-        - *src.offset(1) * *src.offset(7) * *src.offset(14)
-        - *src.offset(5) * *src.offset(2) * *src.offset(15)
-        + *src.offset(5) * *src.offset(3) * *src.offset(14)
-        + *src.offset(13) * *src.offset(2) * *src.offset(7)
-        - *src.offset(13) * *src.offset(3) * *src.offset(6);
-    *dst.offset(6) = -*src.offset(0) * *src.offset(6) * *src.offset(15)
-        + *src.offset(0) * *src.offset(7) * *src.offset(14)
-        + *src.offset(4) * *src.offset(2) * *src.offset(15)
-        - *src.offset(4) * *src.offset(3) * *src.offset(14)
-        - *src.offset(12) * *src.offset(2) * *src.offset(7)
-        + *src.offset(12) * *src.offset(3) * *src.offset(6);
-    *dst.offset(10) = *src.offset(0) * *src.offset(5) * *src.offset(15)
-        - *src.offset(0) * *src.offset(7) * *src.offset(13)
-        - *src.offset(4) * *src.offset(1) * *src.offset(15)
-        + *src.offset(4) * *src.offset(3) * *src.offset(13)
-        + *src.offset(12) * *src.offset(1) * *src.offset(7)
-        - *src.offset(12) * *src.offset(3) * *src.offset(5);
-    *dst.offset(14) = -*src.offset(0) * *src.offset(5) * *src.offset(14)
-        + *src.offset(0) * *src.offset(6) * *src.offset(13)
-        + *src.offset(4) * *src.offset(1) * *src.offset(14)
-        - *src.offset(4) * *src.offset(2) * *src.offset(13)
-        - *src.offset(12) * *src.offset(1) * *src.offset(6)
-        + *src.offset(12) * *src.offset(2) * *src.offset(5);
-    *dst.offset(3) = -*src.offset(1) * *src.offset(6) * *src.offset(11)
-        + *src.offset(1) * *src.offset(7) * *src.offset(10)
-        + *src.offset(5) * *src.offset(2) * *src.offset(11)
-        - *src.offset(5) * *src.offset(3) * *src.offset(10)
-        - *src.offset(9) * *src.offset(2) * *src.offset(7)
-        + *src.offset(9) * *src.offset(3) * *src.offset(6);
-    *dst.offset(7) = *src.offset(0) * *src.offset(6) * *src.offset(11)
-        - *src.offset(0) * *src.offset(7) * *src.offset(10)
-        - *src.offset(4) * *src.offset(2) * *src.offset(11)
-        + *src.offset(4) * *src.offset(3) * *src.offset(10)
-        + *src.offset(8) * *src.offset(2) * *src.offset(7)
-        - *src.offset(8) * *src.offset(3) * *src.offset(6);
-    *dst.offset(11) = -*src.offset(0) * *src.offset(5) * *src.offset(11)
-        + *src.offset(0) * *src.offset(7) * *src.offset(9)
-        + *src.offset(4) * *src.offset(1) * *src.offset(11)
-        - *src.offset(4) * *src.offset(3) * *src.offset(9)
-        - *src.offset(8) * *src.offset(1) * *src.offset(7)
-        + *src.offset(8) * *src.offset(3) * *src.offset(5);
-    *dst.offset(15) = *src.offset(0) * *src.offset(5) * *src.offset(10)
-        - *src.offset(0) * *src.offset(6) * *src.offset(9)
-        - *src.offset(4) * *src.offset(1) * *src.offset(10)
-        + *src.offset(4) * *src.offset(2) * *src.offset(9)
-        + *src.offset(8) * *src.offset(1) * *src.offset(6)
-        - *src.offset(8) * *src.offset(2) * *src.offset(5);
-    let det: f32 = 1.0f32
-        / (*src.offset(0) * *dst.offset(0)
-            + *src.offset(1) * *dst.offset(4)
-            + *src.offset(2) * *dst.offset(8)
-            + *src.offset(3) * *dst.offset(12));
-    let mut i: i32 = 0;
-    while i < 16 {
-        *dst.offset(i as isize) *= det;
-        i += 1;
-    }
-}
-
-unsafe extern "C" fn Matrix_IOTranspose(in_0: &Matrix, out: &mut Matrix) {
-    let src: *const f32 = in_0 as *const Matrix as *const f32;
-    let dst: *mut f32 = out as *mut Matrix as *mut f32;
-    *dst.offset(0) = *src.offset(0);
-    *dst.offset(1) = *src.offset(4);
-    *dst.offset(2) = *src.offset(8);
-    *dst.offset(3) = *src.offset(12);
-    *dst.offset(4) = *src.offset(1);
-    *dst.offset(5) = *src.offset(5);
-    *dst.offset(6) = *src.offset(9);
-    *dst.offset(7) = *src.offset(13);
-    *dst.offset(8) = *src.offset(2);
-    *dst.offset(9) = *src.offset(6);
-    *dst.offset(10) = *src.offset(10);
-    *dst.offset(11) = *src.offset(14);
-    *dst.offset(12) = *src.offset(3);
-    *dst.offset(13) = *src.offset(7);
-    *dst.offset(14) = *src.offset(11);
-    *dst.offset(15) = *src.offset(15);
-}
-
 #[no_mangle]
 pub extern "C" fn Matrix_Equal(a: &Matrix, b: &Matrix) -> bool {
-    let mut i: i32 = 0;
-    while i < 16 {
-        if (*a).m[i as usize] != (*b).m[i as usize] {
-            return false;
-        }
-        i += 1;
-    }
-    true
+    *a == *b
 }
 
 #[no_mangle]
 pub extern "C" fn Matrix_ApproximatelyEqual(a: &Matrix, b: &Matrix) -> bool {
-    let mut i: i32 = 0;
-    while i < 16 {
-        if !Float_ApproximatelyEqual((*a).m[i as usize] as f64, (*b).m[i as usize] as f64) {
-            return false;
+    for row in 0..3 {
+        for col in 0..3 {
+            if !Float_ApproximatelyEqualf(a.col(col)[row], b.col(col)[row]) {
+                return false;
+            }
         }
-        i += 1;
     }
     true
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Matrix_Inverse(this: &Matrix) -> Box<Matrix> {
-    let mut result: Matrix = Matrix { m: [0.; 16] };
-    Matrix_IOInverse(this, &mut result);
-    Matrix_Clone(&result)
+pub extern "C" fn Matrix_Inverse(this: &Matrix) -> Box<Matrix> {
+    Box::new(this.inverse())
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Matrix_InverseTranspose(this: &Matrix) -> Box<Matrix> {
-    let mut inverse: Matrix = Matrix { m: [0.; 16] };
-    let mut result: Matrix = Matrix { m: [0.; 16] };
-    Matrix_IOInverse(this, &mut inverse);
-    Matrix_IOTranspose(&mut inverse, &mut result);
-    Matrix_Clone(&result)
+pub extern "C" fn Matrix_InverseTranspose(this: &Matrix) -> Box<Matrix> {
+    Box::new(this.inverse().transpose())
 }
 
 #[no_mangle]
 pub extern "C" fn Matrix_Sum(a: &Matrix, b: &Matrix) -> Box<Matrix> {
-    let mut result: Matrix = Matrix { m: [0.; 16] };
-    let mut i: i32 = 0;
-    while i < 16 {
-        result.m[i as usize] = (*a).m[i as usize] + (*b).m[i as usize];
-        i += 1;
-    }
-    Matrix_Clone(&result)
+    Box::new(*a + *b)
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Matrix_Transpose(this: &Matrix) -> Box<Matrix> {
-    let mut result: Matrix = Matrix { m: [0.; 16] };
-    Matrix_IOTranspose(this, &mut result);
-    Matrix_Clone(&result)
+pub extern "C" fn Matrix_Transpose(this: &Matrix) -> Box<Matrix> {
+    Box::new(this.transpose())
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Matrix_IInverse(this: &mut Matrix) {
-    let mut result: Matrix = Matrix { m: [0.; 16] };
-    Matrix_IOInverse(this, &mut result);
-    *this = result;
+pub extern "C" fn Matrix_IInverse(this: &mut Matrix) {
+    *this = this.inverse();
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Matrix_IScale(this: &mut Matrix, scale: f32) {
-    let m: *mut f32 = (this.m).as_mut_ptr();
-    *m.offset(0) *= scale;
-    *m.offset(1) *= scale;
-    *m.offset(2) *= scale;
-    *m.offset(4) *= scale;
-    *m.offset(5) *= scale;
-    *m.offset(6) *= scale;
-    *m.offset(8) *= scale;
-    *m.offset(9) *= scale;
-    *m.offset(10) *= scale;
+pub extern "C" fn Matrix_IScale(this: &mut Matrix, scale: f32) {
+    *this *= Mat4::from_scale(Vec3::splat(scale))
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Matrix_ITranspose(this: &mut Matrix) {
-    let mut result: Matrix = Matrix { m: [0.; 16] };
-    Matrix_IOTranspose(this, &mut result);
-    *this = result;
+pub extern "C" fn Matrix_ITranspose(this: &mut Matrix) {
+    *this = this.transpose();
 }
 
 #[no_mangle]
 pub extern "C" fn Matrix_Identity() -> Box<Matrix> {
-    let identity: Matrix = Matrix {
-        m: [
-            1.0f32, 0.0f32, 0.0f32, 0.0f32, 0.0f32, 1.0f32, 0.0f32, 0.0f32, 0.0f32, 0.0f32, 1.0f32,
-            0.0f32, 0.0f32, 0.0f32, 0.0f32, 1.0f32,
-        ],
-    };
-    Matrix_Clone(&identity)
+    Box::new(Matrix::IDENTITY)
 }
 
 #[no_mangle]
 pub extern "C" fn Matrix_LookAt(pos: &Vec3, at: &Vec3, up: &Vec3) -> Box<Matrix> {
-    let z: Vec3 = (*pos - *at).normalize();
-    let x: Vec3 = Vec3::cross(*up, z).normalize();
-    let y: Vec3 = Vec3::cross(z, x);
-    let result: Matrix = Matrix {
-        m: [
-            x.x, y.x, z.x, pos.x, x.y, y.y, z.y, pos.y, x.z, y.z, z.z, pos.z, 0.0f32, 0.0f32,
-            0.0f32, 1.0f32,
-        ],
-    };
-    Matrix_Clone(&result)
+    Box::new(Matrix::look_at_rh(*pos, *at, *up))
 }
 
 #[no_mangle]
 pub extern "C" fn Matrix_LookUp(pos: &Vec3, look: &Vec3, up: &Vec3) -> Box<Matrix> {
-    let z: Vec3 = (*look * -1.0f32).normalize();
-    let x: Vec3 = Vec3::cross(*up, z).normalize();
-    let y: Vec3 = Vec3::cross(z, x);
-    let result: Matrix = Matrix {
-        m: [
-            x.x, y.x, z.x, pos.x, x.y, y.y, z.y, pos.y, x.z, y.z, z.z, pos.z, 0.0f32, 0.0f32,
-            0.0f32, 1.0f32,
-        ],
-    };
-    Matrix_Clone(&result)
+    // The equvalent function in glam would be:
+    // Matrix::look_to_rh(*pos, *look, *up).inverse()
+    //
+    // but as inversing a matrix is expensive, compute the "look to" camera matrix directly.
+    let f: Vec3 = look.normalize();
+    let s: Vec3 = Vec3::cross(f, *up).normalize();
+    let u: Vec3 = Vec3::cross(s, f);
+    Box::new(Matrix::from_cols(
+        s.extend(0.0),
+        u.extend(0.0),
+        -f.extend(0.0),
+        pos.extend(1.0),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn Matrix_Perspective(degreesFovy: f32, aspect: f32, N: f32, F: f32) -> Box<Matrix> {
-    let rads: f64 = (std::f32::consts::PI * degreesFovy) as f64 / 360.0f64;
-    let cot: f64 = 1.0f64 / f64::tan(rads);
-    let result: Matrix = Matrix {
-        m: [
-            (cot / aspect as f64) as f32,
-            0.0f32,
-            0.0f32,
-            0.0f32,
-            0.0f32,
-            cot as f32,
-            0.0f32,
-            0.0f32,
-            0.0f32,
-            0.0f32,
-            (N + F) / (N - F),
-            (2.0f64 * (F * N) as f64 / (N - F) as f64) as f32,
-            0.0f32,
-            0.0f32,
-            -1.0f32,
-            0.0f32,
-        ],
-    };
-    Matrix_Clone(&result)
+    Box::new(Matrix::perspective_rh_gl(
+        f32::to_radians(degreesFovy),
+        aspect,
+        N,
+        F,
+    ))
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Matrix_Product(a: &Matrix, b: &Matrix) -> Box<Matrix> {
-    let mut result: Matrix = Matrix { m: [0.; 16] };
-    let mut pResult: *mut f32 = (result.m).as_mut_ptr();
-    let mut i: i32 = 0;
-    while i < 4 {
-        let mut j: i32 = 0;
-        while j < 4 {
-            let mut sum: f32 = 0.0f32;
-            let mut k: i32 = 0;
-            while k < 4 {
-                sum += (*a).m[(4 * i + k) as usize] * (*b).m[(4 * k + j) as usize];
-                k += 1;
-            }
-            let fresh0 = pResult;
-            pResult = pResult.offset(1);
-            *fresh0 = sum;
-            j += 1;
-        }
-        i += 1;
-    }
-    Matrix_Clone(&result)
+pub extern "C" fn Matrix_Product(a: &Matrix, b: &Matrix) -> Box<Matrix> {
+    Box::new(a.mul_mat4(b))
 }
 
 #[no_mangle]
 pub extern "C" fn Matrix_RotationX(rads: f32) -> Box<Matrix> {
-    let c: f32 = f64::cos(rads as f64) as f32;
-    let s: f32 = f64::sin(rads as f64) as f32;
-    let result: Matrix = Matrix {
-        m: [
-            1.0f32, 0.0f32, 0.0f32, 0.0f32, 0.0f32, c, -s, 0.0f32, 0.0f32, s, c, 0.0f32, 0.0f32,
-            0.0f32, 0.0f32, 1.0f32,
-        ],
-    };
-    Matrix_Clone(&result)
+    Box::new(Matrix::from_rotation_x(rads))
 }
 
 #[no_mangle]
 pub extern "C" fn Matrix_RotationY(rads: f32) -> Box<Matrix> {
-    let c: f32 = f64::cos(rads as f64) as f32;
-    let s: f32 = f64::sin(rads as f64) as f32;
-    let result: Matrix = Matrix {
-        m: [
-            c, 0.0f32, s, 0.0f32, 0.0f32, 1.0f32, 0.0f32, 0.0f32, -s, 0.0f32, c, 0.0f32, 0.0f32,
-            0.0f32, 0.0f32, 1.0f32,
-        ],
-    };
-    Matrix_Clone(&result)
+    Box::new(Matrix::from_rotation_y(rads))
 }
 
 #[no_mangle]
 pub extern "C" fn Matrix_RotationZ(rads: f32) -> Box<Matrix> {
-    let c: f32 = f64::cos(rads as f64) as f32;
-    let s: f32 = f64::sin(rads as f64) as f32;
-    let result: Matrix = Matrix {
-        m: [
-            c, -s, 0.0f32, 0.0f32, s, c, 0.0f32, 0.0f32, 0.0f32, 0.0f32, 1.0f32, 0.0f32, 0.0f32,
-            0.0f32, 0.0f32, 1.0f32,
-        ],
-    };
-    Matrix_Clone(&result)
+    Box::new(Matrix::from_rotation_z(rads))
 }
 
 #[no_mangle]
 pub extern "C" fn Matrix_Scaling(sx: f32, sy: f32, sz: f32) -> Box<Matrix> {
-    let result: Matrix = Matrix {
-        m: [
-            sx, 0.0f32, 0.0f32, 0.0f32, 0.0f32, sy, 0.0f32, 0.0f32, 0.0f32, 0.0f32, sz, 0.0f32,
-            0.0f32, 0.0f32, 0.0f32, 1.0f32,
-        ],
-    };
-    Matrix_Clone(&result)
+    Box::new(Matrix::from_scale(Vec3::new(sx, sy, sz)))
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Matrix_SRT(
+pub extern "C" fn Matrix_SRT(
     sx: f32,
     sy: f32,
     sz: f32,
@@ -420,289 +168,133 @@ pub unsafe extern "C" fn Matrix_SRT(
     ty: f32,
     tz: f32,
 ) -> Box<Matrix> {
-    let S: Box<Matrix> = Matrix_Scaling(sx, sy, sz);
-    let R: Box<Matrix> = Matrix_YawPitchRoll(ry, rp, rr);
-    let T: Box<Matrix> = Matrix_Translation(tx, ty, tz);
-    let TR: Box<Matrix> = Matrix_Product(T.as_ref(), R.as_ref());
-    let TRS: Box<Matrix> = Matrix_Product(TR.as_ref(), S.as_ref());
-    TRS
+    Box::new(Matrix::from_scale_rotation_translation(
+        Vec3::new(sx, sy, sz),
+        Quat::from_euler(glam::EulerRot::ZYX, rr, ry, rp),
+        Vec3::new(tx, ty, tz),
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn Matrix_Translation(tx: f32, ty: f32, tz: f32) -> Box<Matrix> {
-    let result: Matrix = Matrix {
-        m: [
-            1.0f32, 0.0f32, 0.0f32, tx, 0.0f32, 1.0f32, 0.0f32, ty, 0.0f32, 0.0f32, 1.0f32, tz,
-            0.0f32, 0.0f32, 0.0f32, 1.0f32,
-        ],
-    };
-    Matrix_Clone(&result)
+    Box::new(Matrix::from_translation(Vec3::new(tx, ty, tz)))
 }
 
 #[no_mangle]
 pub extern "C" fn Matrix_YawPitchRoll(yaw: f32, pitch: f32, roll: f32) -> Box<Matrix> {
-    let ca: f32 = f64::cos(roll as f64) as f32;
-    let sa: f32 = f64::sin(roll as f64) as f32;
-    let cb: f32 = f64::cos(yaw as f64) as f32;
-    let sb: f32 = f64::sin(yaw as f64) as f32;
-    let cy: f32 = f64::cos(pitch as f64) as f32;
-    let sy: f32 = f64::sin(pitch as f64) as f32;
-    let result: Matrix = Matrix {
-        m: [
-            ca * cb,
-            ca * sb * sy - sa * cy,
-            ca * sb * cy + sa * sy,
-            0.0f32,
-            sa * cb,
-            sa * sb * sy + ca * cy,
-            sa * sb * cy - ca * sy,
-            0.0f32,
-            -sb,
-            cb * sy,
-            cb * cy,
-            0.0f32,
-            0.0f32,
-            0.0f32,
-            0.0f32,
-            1.0f32,
-        ],
-    };
-    Matrix_Clone(&result)
+    Box::new(Matrix::from_quat(Quat::from_euler(
+        glam::EulerRot::ZYX,
+        roll,
+        yaw,
+        pitch,
+    )))
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Matrix_MulBox(this: &Matrix, out: &mut Box3, in_0: &Box3) {
+pub extern "C" fn Matrix_MulBox(this: &Matrix, out: &mut Box3, in_0: &Box3) {
     let corners: [Vec3; 8] = [
-        Vec3 {
-            x: (*in_0).lower.x,
-            y: (*in_0).lower.y,
-            z: (*in_0).lower.z,
-        },
-        Vec3 {
-            x: (*in_0).upper.x,
-            y: (*in_0).lower.y,
-            z: (*in_0).lower.z,
-        },
-        Vec3 {
-            x: (*in_0).lower.x,
-            y: (*in_0).upper.y,
-            z: (*in_0).lower.z,
-        },
-        Vec3 {
-            x: (*in_0).upper.x,
-            y: (*in_0).upper.y,
-            z: (*in_0).lower.z,
-        },
-        Vec3 {
-            x: (*in_0).lower.x,
-            y: (*in_0).lower.y,
-            z: (*in_0).upper.z,
-        },
-        Vec3 {
-            x: (*in_0).upper.x,
-            y: (*in_0).lower.y,
-            z: (*in_0).upper.z,
-        },
-        Vec3 {
-            x: (*in_0).lower.x,
-            y: (*in_0).upper.y,
-            z: (*in_0).upper.z,
-        },
-        Vec3 {
-            x: (*in_0).upper.x,
-            y: (*in_0).upper.y,
-            z: (*in_0).upper.z,
-        },
+        Vec3::new(in_0.lower.x, in_0.lower.y, in_0.lower.z),
+        Vec3::new(in_0.upper.x, in_0.lower.y, in_0.lower.z),
+        Vec3::new(in_0.lower.x, in_0.upper.y, in_0.lower.z),
+        Vec3::new(in_0.upper.x, in_0.upper.y, in_0.lower.z),
+        Vec3::new(in_0.lower.x, in_0.lower.y, in_0.upper.z),
+        Vec3::new(in_0.upper.x, in_0.lower.y, in_0.upper.z),
+        Vec3::new(in_0.lower.x, in_0.upper.y, in_0.upper.z),
+        Vec3::new(in_0.upper.x, in_0.upper.y, in_0.upper.z),
     ];
-    let mut result = Vec3::ZERO;
-    Matrix_MulPoint(this, &mut result, corners[0].x, corners[0].y, corners[0].z);
-    out.lower = result;
-    out.upper = result;
-    let mut i: i32 = 1;
-    while i < 8 {
-        Matrix_MulPoint(
-            this,
-            &mut result,
-            corners[i as usize].x,
-            corners[i as usize].y,
-            corners[i as usize].z,
-        );
+
+    out.lower = this.transform_point3(corners[0]);
+    out.upper = out.lower;
+    for i in 1..8 {
+        let result = this.transform_point3(corners[i]);
         out.lower = Vec3::min(out.lower, result);
         out.upper = Vec3::max(out.upper, result);
-        i += 1;
     }
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Matrix_MulDir(this: &Matrix, out: &mut Vec3, x: f32, y: f32, z: f32) {
-    let m: *const f32 = (this.m).as_ptr();
-    out.x = *m.offset(0) * x + *m.offset(1) * y + *m.offset(2) * z;
-    out.y = *m.offset(4) * x + *m.offset(5) * y + *m.offset(6) * z;
-    out.z = *m.offset(8) * x + *m.offset(9) * y + *m.offset(10) * z;
+pub extern "C" fn Matrix_MulDir(this: &Matrix, out: &mut Vec3, x: f32, y: f32, z: f32) {
+    *out = this.transform_vector3(Vec3::new(x, y, z));
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Matrix_MulPoint(this: &Matrix, out: &mut Vec3, x: f32, y: f32, z: f32) {
-    let m: *const f32 = (this.m).as_ptr();
-    out.x = *m.offset(0) * x + *m.offset(1) * y + *m.offset(2) * z + *m.offset(3);
-    out.y = *m.offset(4) * x + *m.offset(5) * y + *m.offset(6) * z + *m.offset(7);
-    out.z = *m.offset(8) * x + *m.offset(9) * y + *m.offset(10) * z + *m.offset(11);
+pub extern "C" fn Matrix_MulPoint(this: &Matrix, out: &mut Vec3, x: f32, y: f32, z: f32) {
+    *out = this.transform_point3(Vec3::new(x, y, z));
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Matrix_MulVec(
-    this: &Matrix,
-    out: &mut Vec4,
-    x: f32,
-    y: f32,
-    z: f32,
-    w: f32,
-) {
-    let m: *const f32 = (this.m).as_ptr();
-    out.x = *m.offset(0) * x + *m.offset(1) * y + *m.offset(2) * z + *m.offset(3) * w;
-    out.y = *m.offset(4) * x + *m.offset(5) * y + *m.offset(6) * z + *m.offset(7) * w;
-    out.z = *m.offset(8) * x + *m.offset(9) * y + *m.offset(10) * z + *m.offset(11) * w;
-    out.w = *m.offset(12) * x + *m.offset(13) * y + *m.offset(14) * z + *m.offset(15) * w;
+pub extern "C" fn Matrix_MulVec(this: &Matrix, out: &mut Vec4, x: f32, y: f32, z: f32, w: f32) {
+    *out = this.mul_vec4(Vec4::new(x, y, z, w));
 }
 
 #[no_mangle]
 pub extern "C" fn Matrix_GetForward(this: &Matrix, out: &mut Vec3) {
-    out.x = -this.m[2];
-    out.y = -this.m[6];
-    out.z = -this.m[10];
+    *out = this.get_forward();
 }
 
 #[no_mangle]
 pub extern "C" fn Matrix_GetRight(this: &Matrix, out: &mut Vec3) {
-    out.x = this.m[0];
-    out.y = this.m[4];
-    out.z = this.m[8];
+    *out = this.get_right();
 }
 
 #[no_mangle]
 pub extern "C" fn Matrix_GetUp(this: &Matrix, out: &mut Vec3) {
-    out.x = this.m[1];
-    out.y = this.m[5];
-    out.z = this.m[9];
+    *out = this.get_up();
 }
 
 #[no_mangle]
 pub extern "C" fn Matrix_GetPos(this: &Matrix, out: &mut Vec3) {
-    out.x = this.m[3];
-    out.y = this.m[7];
-    out.z = this.m[11];
+    *out = this.get_translation();
 }
 
 #[no_mangle]
 pub extern "C" fn Matrix_GetRow(this: &Matrix, out: &mut Vec4, row: i32) {
-    out.x = this.m[(4 * row + 0) as usize];
-    out.y = this.m[(4 * row + 1) as usize];
-    out.z = this.m[(4 * row + 2) as usize];
-    out.w = this.m[(4 * row + 3) as usize];
+    *out = this.row(row as usize);
 }
 
 #[no_mangle]
 pub extern "C" fn Matrix_FromBasis(x: &Vec3, y: &Vec3, z: &Vec3) -> Box<Matrix> {
-    let result: Matrix = Matrix {
-        m: [
-            x.x, y.x, z.x, 0.0f32, x.y, y.y, z.y, 0.0f32, x.z, y.z, z.z, 0.0f32, 0.0f32, 0.0f32,
-            0.0f32, 1.0f32,
-        ],
-    };
-    Matrix_Clone(&result)
+    Box::new(Matrix::from_mat3(Mat3::from_cols(*x, *y, *z)))
 }
 
 #[no_mangle]
 pub extern "C" fn Matrix_FromPosRot(pos: &Vec3, rot: &Quat) -> Box<Matrix> {
-    let mut x = Vec3::ZERO;
-    Quat_GetAxisX(rot, &mut x);
-    let mut y = Vec3::ZERO;
-    Quat_GetAxisY(rot, &mut y);
-    let mut z = Vec3::ZERO;
-    Quat_GetAxisZ(rot, &mut z);
-    let result: Matrix = Matrix {
-        m: [
-            x.x, y.x, z.x, pos.x, x.y, y.y, z.y, pos.y, x.z, y.z, z.z, pos.z, 0.0f32, 0.0f32,
-            0.0f32, 1.0f32,
-        ],
-    };
-    Matrix_Clone(&result)
+    Box::new(Matrix::from_rotation_translation(*rot, *pos))
 }
 
 #[no_mangle]
 pub extern "C" fn Matrix_FromPosRotScale(pos: &Vec3, rot: &Quat, scale: f32) -> Box<Matrix> {
-    let mut x = Vec3::ZERO;
-    Quat_GetAxisX(rot, &mut x);
-    let mut y = Vec3::ZERO;
-    Quat_GetAxisY(rot, &mut y);
-    let mut z = Vec3::ZERO;
-    Quat_GetAxisZ(rot, &mut z);
-    let result: Matrix = Matrix {
-        m: [
-            scale * x.x,
-            scale * y.x,
-            scale * z.x,
-            pos.x,
-            scale * x.y,
-            scale * y.y,
-            scale * z.y,
-            pos.y,
-            scale * x.z,
-            scale * y.z,
-            scale * z.z,
-            pos.z,
-            0.0f32,
-            0.0f32,
-            0.0f32,
-            1.0f32,
-        ],
-    };
-    Matrix_Clone(&result)
+    Box::new(Matrix::from_scale_rotation_translation(
+        Vec3::splat(scale),
+        *rot,
+        *pos,
+    ))
 }
 
 #[no_mangle]
 pub extern "C" fn Matrix_FromPosBasis(pos: &Vec3, x: &Vec3, y: &Vec3, z: &Vec3) -> Box<Matrix> {
-    let result: Matrix = Matrix {
-        m: [
-            x.x, y.x, z.x, pos.x, x.y, y.y, z.y, pos.y, x.z, y.z, z.z, pos.z, 0.0f32, 0.0f32,
-            0.0f32, 1.0f32,
-        ],
-    };
-    Matrix_Clone(&result)
+    let mut mat_from_basis = Box::new(Matrix::from_mat3(Mat3::from_cols(*x, *y, *z)));
+    mat_from_basis.w_axis.x = pos.x;
+    mat_from_basis.w_axis.y = pos.y;
+    mat_from_basis.w_axis.z = pos.z;
+    mat_from_basis
 }
 
 #[no_mangle]
 pub extern "C" fn Matrix_FromQuat(q: &Quat) -> Box<Matrix> {
-    let mut x = Vec3::ZERO;
-    Quat_GetAxisX(q, &mut x);
-    let mut y = Vec3::ZERO;
-    Quat_GetAxisY(q, &mut y);
-    let mut z = Vec3::ZERO;
-    Quat_GetAxisZ(q, &mut z);
-    let result: Matrix = Matrix {
-        m: [
-            x.x, y.x, z.x, 0.0f32, x.y, y.y, z.y, 0.0f32, x.z, y.z, z.z, 0.0f32, 0.0f32, 0.0f32,
-            0.0f32, 1.0f32,
-        ],
-    };
-    Matrix_Clone(&result)
+    Box::new(Matrix::from_quat(*q))
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Matrix_ToQuat(this: &Matrix, q: &mut Quat) {
-    let m: *const f32 = this as *const Matrix as *const f32;
-    let mut x: Vec3 = Vec3::new(*m.offset(0), *m.offset(4), *m.offset(8));
-    let mut y: Vec3 = Vec3::new(*m.offset(1), *m.offset(5), *m.offset(9));
-    let mut z: Vec3 = Vec3::new(*m.offset(2), *m.offset(6), *m.offset(10));
-    Quat_FromBasis(&mut x, &mut y, &mut z, q);
+pub extern "C" fn Matrix_ToQuat(this: &Matrix, q: &mut Quat) {
+    *q = Quat::from_mat4(this);
 }
 
 #[no_mangle]
 pub extern "C" fn Matrix_Print(this: &Matrix) {
-    for i in 0..4 {
-        let v = &this.m[i * 4..(i + 1) * 4];
-        let s: Vec<_> = v.iter().map(|v| format!("{v}")).collect();
-
+    for r in 0..4 {
+        let row = this.row(r);
+        let s = row.as_ref().map(|elem| format!("{elem}"));
         info!("{}", s.join(" "));
     }
 }

--- a/engine/lib/phx/src/math/mod.rs
+++ b/engine/lib/phx/src/math/mod.rs
@@ -1,4 +1,5 @@
 mod bit;
+mod box3;
 mod clip_rect;
 mod intersect;
 mod line_segment;
@@ -14,6 +15,7 @@ mod triangle;
 mod vec2;
 
 pub use bit::*;
+pub use box3::*;
 pub use clip_rect::*;
 pub use intersect::*;
 pub use line_segment::*;

--- a/engine/lib/phx/src/math/quat.rs
+++ b/engine/lib/phx/src/math/quat.rs
@@ -2,27 +2,58 @@ use crate::internal::*;
 use crate::math::*;
 use crate::*;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Quat {
-    pub x: f32,
-    pub y: f32,
-    pub z: f32,
-    pub w: f32,
+pub use glam::Quat;
+
+pub trait QuatExtensions {
+    fn canonicalize(&self) -> Quat;
+    fn get_axis_x(&self) -> Vec3;
+    fn get_axis_y(&self) -> Vec3;
+    fn get_axis_z(&self) -> Vec3;
 }
 
-impl Quat {
-    pub fn to_string(&self) -> String {
-        format!(
-            "({:.4}, {:.4}, {:.4}, {:.4})",
-            self.x, self.y, self.z, self.w
-        )
+impl QuatExtensions for Quat {
+    fn canonicalize(&self) -> Quat {
+        let value: f32 = if !Float_ApproximatelyEqualf(self.w, 0.0) {
+            self.w
+        } else if !Float_ApproximatelyEqualf(self.z, 0.0) {
+            self.z
+        } else if !Float_ApproximatelyEqualf(self.y, 0.0) {
+            self.y
+        } else if !Float_ApproximatelyEqualf(self.x, 0.0) {
+            self.x
+        } else {
+            0.0
+        };
+        if value < 0.0 {
+            -*self
+        } else {
+            *self
+        }
     }
-}
 
-#[inline]
-extern "C" fn Float_ApproximatelyEqual(x: f64, y: f64) -> bool {
-    f64::abs(x - y) < 1e-3f64
+    fn get_axis_x(&self) -> Vec3 {
+        Vec3 {
+            x: 1.0 - 2.0 * (self.y * self.y + self.z * self.z),
+            y: 2.0 * (self.x * self.y + self.z * self.w),
+            z: 2.0 * (self.x * self.z - self.y * self.w),
+        }
+    }
+
+    fn get_axis_y(&self) -> Vec3 {
+        Vec3 {
+            x: 2.0 * (self.x * self.y - self.z * self.w),
+            y: 1.0 - 2.0 * (self.x * self.x + self.z * self.z),
+            z: 2.0 * (self.y * self.z + self.x * self.w),
+        }
+    }
+
+    fn get_axis_z(&self) -> Vec3 {
+        Vec3 {
+            x: 2.0 * (self.x * self.z + self.y * self.w),
+            y: 2.0 * (self.y * self.z - self.x * self.w),
+            z: 1.0 - 2.0 * (self.x * self.x + self.y * self.y),
+        }
+    }
 }
 
 #[no_mangle]
@@ -32,235 +63,112 @@ pub extern "C" fn Quat_Create(x: f32, y: f32, z: f32, w: f32) -> Quat {
 
 #[no_mangle]
 pub extern "C" fn Quat_GetAxisX(q: &Quat, out: &mut Vec3) {
-    // out = q.
-    out.x = 1.0f32 - 2.0f32 * (q.y * q.y + q.z * q.z);
-    out.y = 2.0f32 * (q.x * q.y + q.z * q.w);
-    out.z = 2.0f32 * (q.x * q.z - q.y * q.w);
+    *out = q.get_axis_x()
 }
 
 #[no_mangle]
 pub extern "C" fn Quat_GetAxisY(q: &Quat, out: &mut Vec3) {
-    out.x = 2.0f32 * (q.x * q.y - q.z * q.w);
-    out.y = 1.0f32 - 2.0f32 * (q.x * q.x + q.z * q.z);
-    out.z = 2.0f32 * (q.y * q.z + q.x * q.w);
+    *out = q.get_axis_y()
 }
 
 #[no_mangle]
 pub extern "C" fn Quat_GetAxisZ(q: &Quat, out: &mut Vec3) {
-    out.x = 2.0f32 * (q.x * q.z + q.y * q.w);
-    out.y = 2.0f32 * (q.y * q.z - q.x * q.w);
-    out.z = 1.0f32 - 2.0f32 * (q.x * q.x + q.y * q.y);
+    *out = q.get_axis_z()
 }
 
 #[no_mangle]
 pub extern "C" fn Quat_GetForward(q: &Quat, out: &mut Vec3) {
-    Quat_GetAxisZ(q, out);
-    out.x = -out.x;
-    out.y = -out.y;
-    out.z = -out.z;
+    *out = -q.get_axis_z();
 }
 
 #[no_mangle]
 pub extern "C" fn Quat_GetRight(q: &Quat, out: &mut Vec3) {
-    Quat_GetAxisX(q, out);
+    *out = q.get_axis_x();
 }
 
 #[no_mangle]
 pub extern "C" fn Quat_GetUp(q: &Quat, out: &mut Vec3) {
-    Quat_GetAxisY(q, out);
+    *out = q.get_axis_y();
 }
 
 #[no_mangle]
 pub extern "C" fn Quat_Identity(out: &mut Quat) {
-    out.x = 0.0f32;
-    out.y = 0.0f32;
-    out.z = 0.0f32;
-    out.w = 1.0f32;
+    *out = Quat::IDENTITY;
 }
 
 #[no_mangle]
 pub extern "C" fn Quat_Canonicalize(q: &Quat, out: &mut Quat) {
-    let value: f32 = if !Float_ApproximatelyEqual(q.w as f64, 0.0f64) {
-        q.w
-    } else if !Float_ApproximatelyEqual(q.z as f64, 0.0f64) {
-        q.z
-    } else if !Float_ApproximatelyEqual(q.y as f64, 0.0f64) {
-        q.y
-    } else if !Float_ApproximatelyEqual(q.x as f64, 0.0f64) {
-        q.x
-    } else {
-        0.0f32
-    };
-    if value < 0.0f32 {
-        out.x = -q.x;
-        out.y = -q.y;
-        out.z = -q.z;
-        out.w = -q.w;
-    } else {
-        out.x = q.x;
-        out.y = q.y;
-        out.z = q.z;
-        out.w = q.w;
-    };
+    *out = q.canonicalize();
 }
 
 #[no_mangle]
 pub extern "C" fn Quat_ICanonicalize(q: &mut Quat) {
-    let value: f32 = if !Float_ApproximatelyEqual(q.w as f64, 0.0f64) {
-        q.w
-    } else if !Float_ApproximatelyEqual(q.z as f64, 0.0f64) {
-        q.z
-    } else if !Float_ApproximatelyEqual(q.y as f64, 0.0f64) {
-        q.y
-    } else if !Float_ApproximatelyEqual(q.x as f64, 0.0f64) {
-        q.x
-    } else {
-        0.0f32
-    };
-    if value < 0.0f32 {
-        q.x = -q.x;
-        q.y = -q.y;
-        q.z = -q.z;
-        q.w = -q.w;
-    }
+    *q = q.canonicalize();
 }
 
 #[no_mangle]
 pub extern "C" fn Quat_Dot(q: &Quat, p: &Quat) -> f32 {
-    q.x * p.x + q.y * p.y + q.z * p.z + q.w * p.w
+    q.dot(*p)
 }
 
 #[no_mangle]
 pub extern "C" fn Quat_Equal(q: &Quat, p: &Quat) -> bool {
-    let mut cq = Quat_Create(0.0f32, 0.0f32, 0.0f32, 0.0f32);
-    Quat_Canonicalize(q, &mut cq);
-    let mut cp = Quat_Create(0.0f32, 0.0f32, 0.0f32, 0.0f32);
-    Quat_Canonicalize(p, &mut cp);
-    cq.x == cp.x && cq.y == cp.y && cq.z == cp.z && cq.w == cp.w
+    q.canonicalize() == p.canonicalize()
 }
 
 #[no_mangle]
 pub extern "C" fn Quat_ApproximatelyEqual(q: &Quat, p: &Quat) -> bool {
-    let mut cq = Quat_Create(0.0f32, 0.0f32, 0.0f32, 0.0f32);
-    Quat_Canonicalize(q, &mut cq);
-    let mut cp = Quat_Create(0.0f32, 0.0f32, 0.0f32, 0.0f32);
-    Quat_Canonicalize(p, &mut cp);
-    f64::abs((cq.x - cp.x) as f64) < 1e-3f64
-        && f64::abs((cq.y - cp.y) as f64) < 1e-3f64
-        && f64::abs((cq.z - cp.z) as f64) < 1e-3f64
-        && f64::abs((cq.w - cp.w) as f64) < 1e-3f64
+    let cq = q.canonicalize();
+    let cp = p.canonicalize();
+    Float_ApproximatelyEqualf(cq.x, cp.x)
+        && Float_ApproximatelyEqualf(cq.y, cp.y)
+        && Float_ApproximatelyEqualf(cq.z, cp.z)
+        && Float_ApproximatelyEqualf(cq.w, cp.w)
 }
 
 #[no_mangle]
 pub extern "C" fn Quat_Inverse(q: &Quat, out: &mut Quat) {
-    let magSq: f32 = q.x * q.x + q.y * q.y + q.z * q.z + q.w * q.w;
-    out.x = -q.x / magSq;
-    out.y = -q.y / magSq;
-    out.z = -q.z / magSq;
-    out.w = q.w / magSq;
+    *out = q.normalize().inverse();
 }
 
 #[no_mangle]
 pub extern "C" fn Quat_IInverse(q: &mut Quat) {
-    let magSq: f32 = q.x * q.x + q.y * q.y + q.z * q.z + q.w * q.w;
-    q.x = -q.x / magSq;
-    q.y = -q.y / magSq;
-    q.z = -q.z / magSq;
-    q.w /= magSq;
+    *q = q.normalize().inverse();
 }
 
 #[no_mangle]
 pub extern "C" fn Quat_Lerp(q: &Quat, p: &Quat, t: f32, out: &mut Quat) {
-    let d: f32 = Quat_Dot(p, q);
-    let mut dp = Quat_Create(0.0f32, 0.0f32, 0.0f32, 0.0f32);
-    if d < 0.0f32 {
-        dp.x = -p.x;
-        dp.y = -p.y;
-        dp.z = -p.z;
-        dp.w = -p.w;
-    } else {
-        dp = *p;
-    }
-    let x: f32 = q.x + (dp.x - q.x) * t;
-    let y: f32 = q.y + (dp.y - q.y) * t;
-    let z: f32 = q.z + (dp.z - q.z) * t;
-    let w: f32 = q.w + (dp.w - q.w) * t;
-    let rcpMag: f32 = (1.0f64 / f64::sqrt((x * x + y * y + z * z + w * w) as f64)) as f32;
-    out.x = x * rcpMag;
-    out.y = y * rcpMag;
-    out.z = z * rcpMag;
-    out.w = w * rcpMag;
+    *out = q.lerp(*p, t);
 }
 
 #[no_mangle]
 pub extern "C" fn Quat_ILerp(q: &mut Quat, p: &Quat, t: f32) {
-    let d: f32 = Quat_Dot(p, q);
-    let mut dp = Quat_Create(0.0f32, 0.0f32, 0.0f32, 0.0f32);
-    if d < 0.0f32 {
-        dp.x = -p.x;
-        dp.y = -p.y;
-        dp.z = -p.z;
-        dp.w = -p.w;
-    } else {
-        dp = *p;
-    }
-    let x: f32 = q.x + (dp.x - q.x) * t;
-    let y: f32 = q.y + (dp.y - q.y) * t;
-    let z: f32 = q.z + (dp.z - q.z) * t;
-    let w: f32 = q.w + (dp.w - q.w) * t;
-    let rcpMag: f32 = (1.0f64 / f64::sqrt((x * x + y * y + z * z + w * w) as f64)) as f32;
-    q.x = x * rcpMag;
-    q.y = y * rcpMag;
-    q.z = z * rcpMag;
-    q.w = w * rcpMag;
+    *q = q.lerp(*p, t);
 }
 
 #[no_mangle]
 pub extern "C" fn Quat_Mul(q: &Quat, p: &Quat, out: &mut Quat) {
-    let qv: Vec3 = Vec3::new(q.x, q.y, q.z);
-    let pv: Vec3 = Vec3::new(p.x, p.y, p.z);
-    let rv: Vec3 = (qv * p.w) + (pv * q.w) + Vec3::cross(qv, pv);
-    out.x = rv.x;
-    out.y = rv.y;
-    out.z = rv.z;
-    out.w = q.w * p.w - Vec3::dot(qv, pv);
+    *out = q.mul_quat(*p);
 }
 
 #[no_mangle]
 pub extern "C" fn Quat_IMul(q: &mut Quat, p: &Quat) {
-    let qv: Vec3 = Vec3::new(q.x, q.y, q.z);
-    let pv: Vec3 = Vec3::new(p.x, p.y, p.z);
-    let rv: Vec3 = (qv * p.w) + (pv * q.w) + Vec3::cross(qv, pv);
-    q.x = rv.x;
-    q.y = rv.y;
-    q.z = rv.z;
-    q.w = q.w * p.w - Vec3::dot(qv, pv);
+    *q = q.mul_quat(*p);
 }
 
 #[no_mangle]
 pub extern "C" fn Quat_MulV(q: &Quat, v: &Vec3, out: &mut Vec3) {
-    let u: Vec3 = Vec3::new(q.x, q.y, q.z);
-    let w: f32 = q.w;
-    let t: Vec3 = Vec3::cross(u, *v);
-    *out = (u * 2.0f32 * Vec3::dot(u, *v)) + ((*v) * (2.0f32 * w * w - 1.0f32)) + (t * 2.0f32 * w);
+    *out = q.mul_vec3(*v);
 }
 
 #[no_mangle]
 pub extern "C" fn Quat_Normalize(q: &Quat, out: &mut Quat) {
-    let mag = f32::sqrt(q.x * q.x + q.y * q.y + q.z * q.z + q.w * q.w);
-    out.x = q.x / mag;
-    out.y = q.y / mag;
-    out.z = q.z / mag;
-    out.w = q.w / mag;
+    *out = q.normalize();
 }
 
 #[no_mangle]
 pub extern "C" fn Quat_INormalize(q: &mut Quat) {
-    let mag = f32::sqrt(q.x * q.x + q.y * q.y + q.z * q.z + q.w * q.w);
-    q.x /= mag;
-    q.y /= mag;
-    q.z /= mag;
-    q.w /= mag;
+    *q = q.normalize();
 }
 
 #[no_mangle]
@@ -281,58 +189,12 @@ pub extern "C" fn Quat_IScale(q: &mut Quat, scale: f32) {
 
 #[no_mangle]
 pub extern "C" fn Quat_Slerp(q: &Quat, p: &Quat, t: f32, out: &mut Quat) {
-    let mut np = Quat_Create(0.0f32, 0.0f32, 0.0f32, 0.0f32);
-    Quat_Normalize(p, &mut np);
-    let mut d: f32 = Quat_Dot(q, p);
-    if d < 0.0f32 {
-        np.x = -np.x;
-        np.y = -np.y;
-        np.z = -np.z;
-        np.w = -np.w;
-        d = -d;
-    }
-    if d > 0.9995f32 {
-        Quat_Lerp(q, p, t, out);
-        return;
-    }
-    d = f32::clamp(d, -1.0f32, 1.0f32);
-    let angle: f32 = t * f32::acos(d);
-    let mut c = Quat_Create(p.x - d * q.x, p.y - d * q.y, p.z - d * q.z, p.w - d * q.w);
-    Quat_INormalize(&mut c);
-    let fa: f32 = f32::cos(angle);
-    let fc: f32 = f32::sin(angle);
-    out.x = fa * q.x + fc * c.x;
-    out.y = fa * q.y + fc * c.y;
-    out.z = fa * q.z + fc * c.z;
-    out.w = fa * q.w + fc * c.w;
+    *out = q.slerp(*p, t);
 }
 
 #[no_mangle]
 pub extern "C" fn Quat_ISlerp(q: &mut Quat, p: &Quat, t: f32) {
-    let mut np = Quat_Create(0.0f32, 0.0f32, 0.0f32, 0.0f32);
-    Quat_Normalize(p, &mut np);
-    let mut d: f32 = Quat_Dot(q, p);
-    if d < 0.0f32 {
-        np.x = -np.x;
-        np.y = -np.y;
-        np.z = -np.z;
-        np.w = -np.w;
-        d = -d;
-    }
-    if d > 0.9995f32 {
-        Quat_ILerp(q, p, t);
-        return;
-    }
-    d = f32::clamp(d, -1.0f32, 1.0f32);
-    let angle: f32 = t * f32::acos(d);
-    let mut c = Quat_Create(p.x - d * q.x, p.y - d * q.y, p.z - d * q.z, p.w - d * q.w);
-    Quat_INormalize(&mut c);
-    let fa: f32 = f32::cos(angle);
-    let fc: f32 = f32::sin(angle);
-    q.x = fa * q.x + fc * c.x;
-    q.y = fa * q.y + fc * c.y;
-    q.z = fa * q.z + fc * c.z;
-    q.w = fa * q.w + fc * c.w;
+    *q = q.slerp(*p, t);
 }
 
 #[no_mangle]
@@ -352,54 +214,25 @@ pub extern "C" fn Quat_Validate(q: &Quat) -> Error {
 
 #[no_mangle]
 pub extern "C" fn Quat_FromAxisAngle(axis: &Vec3, radians: f32, out: &mut Quat) {
-    let v: Vec3 = *axis * f32::sin(radians * 0.5);
-    out.x = v.x;
-    out.y = v.y;
-    out.z = v.z;
-    out.w = f32::cos(radians);
+    *out = Quat::from_axis_angle(*axis, radians);
 }
 
 #[no_mangle]
 pub extern "C" fn Quat_FromBasis(x: &Vec3, y: &Vec3, z: &Vec3, out: &mut Quat) {
-    let r: f32 = x.x + y.y + z.z;
-    if r > 0.0f32 {
-        out.w = (f64::sqrt((r + 1.0f32) as f64) * 0.5f64) as f32;
-        let w4: f32 = 1.0f32 / (4.0f32 * out.w);
-        out.x = (y.z - z.y) * w4;
-        out.y = (z.x - x.z) * w4;
-        out.z = (x.y - y.x) * w4;
-    } else if x.x > y.y && x.x > z.z {
-        out.x = (f64::sqrt((1.0f32 + x.x - y.y - z.z) as f64) * 0.5f64) as f32;
-        let x4: f32 = 1.0f32 / (4.0f32 * out.x);
-        out.y = (y.x + x.y) * x4;
-        out.z = (z.x + x.z) * x4;
-        out.w = (y.z - z.y) * x4;
-    } else if y.y > z.z {
-        out.y = (f64::sqrt((1.0f32 + y.y - x.x - z.z) as f64) * 0.5f64) as f32;
-        let y4: f32 = 1.0f32 / (4.0f32 * out.y);
-        out.x = (y.x + x.y) * y4;
-        out.z = (z.y + y.z) * y4;
-        out.w = (z.x - x.z) * y4;
-    } else {
-        out.z = (f64::sqrt((1.0f32 + z.z - x.x - y.y) as f64) * 0.5f64) as f32;
-        let z4: f32 = 1.0f32 / (4.0f32 * out.z);
-        out.x = (z.x + x.z) * z4;
-        out.y = (z.y + y.z) * z4;
-        out.w = (x.y - y.x) * z4;
-    };
+    *out = Quat::from_mat3(&Mat3::from_cols(*x, *y, *z));
 }
 
 #[no_mangle]
 pub extern "C" fn Quat_FromLookUp(look: &Vec3, up: &Vec3, out: &mut Quat) {
-    let mut z: Vec3 = (*look * -1.0f32).normalize();
-    let mut x: Vec3 = Vec3::cross(*up, z).normalize();
-    let mut y: Vec3 = Vec3::cross(z, x);
-    Quat_FromBasis(&mut x, &mut y, &mut z, out);
+    let z = (*look * -1.0).normalize();
+    let x = Vec3::cross(*up, z).normalize();
+    let y = Vec3::cross(z, x);
+    *out = Quat::from_mat3(&Mat3::from_cols(x, y, z));
 }
 
 #[no_mangle]
 pub extern "C" fn Quat_FromRotateTo(from: &Vec3, to: &Vec3, out: &mut Quat) {
-    let mut axis: Vec3 = Vec3::cross((*from).normalize(), (*to).normalize());
+    let axis = Vec3::cross(from.normalize(), to.normalize());
     let angle = f32::asin(axis.length());
-    Quat_FromAxisAngle(&mut axis, angle, out);
+    *out = Quat::from_axis_angle(axis, angle);
 }

--- a/engine/lib/phx/src/physics/rigid_body.rs
+++ b/engine/lib/phx/src/physics/rigid_body.rs
@@ -205,12 +205,16 @@ pub unsafe extern "C" fn RigidBody_GetSpeed(this: &mut RigidBody) -> f32 {
 
 #[no_mangle]
 pub unsafe extern "C" fn RigidBody_GetToLocalMatrix(this: &mut RigidBody) -> *mut Matrix {
-    _cppRigidBody_GetToLocalMatrix(this)
+    let result = _cppRigidBody_GetToLocalMatrix(this);
+    Matrix_ITranspose(&mut *result);
+    result
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn RigidBody_GetToWorldMatrix(this: &mut RigidBody) -> *mut Matrix {
-    _cppRigidBody_GetToWorldMatrix(this)
+    let result = _cppRigidBody_GetToWorldMatrix(this);
+    Matrix_ITranspose(&mut *result);
+    result
 }
 
 #[no_mangle]

--- a/engine/lib/phx/src/render/gl_matrix.rs
+++ b/engine/lib/phx/src/render/gl_matrix.rs
@@ -1,8 +1,7 @@
 use super::*;
 use crate::math::*;
 
-/* NOTE : LoadMatrix expects column-major memory layout, but we use row-major,
- *        hence the need for transpositions when taking a Matrix*. */
+/* NOTE : LoadMatrix expects column-major memory layout. */
 
 #[no_mangle]
 pub unsafe extern "C" fn GLMatrix_Clear() {
@@ -11,27 +10,13 @@ pub unsafe extern "C" fn GLMatrix_Clear() {
 
 #[no_mangle]
 pub unsafe extern "C" fn GLMatrix_Load(matrix: &mut Matrix) {
-    let m: &[f32; 16] = &matrix.m;
-    let transpose: [f32; 16] = [
-        m[0], m[4], m[8], m[12], m[1], m[5], m[9], m[13], m[2], m[6], m[10], m[14], m[3], m[7],
-        m[11], m[15],
-    ];
-    gl::LoadMatrixf(transpose.as_ptr());
+    gl::LoadMatrixf(matrix.as_ref().as_ptr());
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn GLMatrix_LookAt(eye: *const DVec3, at: *const DVec3, up: *const DVec3) {
-    let z = (*at - *eye).normalize();
-    let x = DVec3::cross(z, (*up).normalize()).normalize();
-    let y = DVec3::cross(x, z);
-
-    /* TODO : Yet another sign flip. Sigh. */
-    let mut m: [f64; 16] = [
-        x.x, y.x, -z.x, 0.0, x.y, y.y, -z.y, 0.0, x.z, y.z, -z.z, 0.0, 0.0, 0.0, 0.0, 1.0,
-    ];
-
-    gl::MultMatrixd(m.as_mut_ptr());
-    gl::Translated(-(*eye).x, -(*eye).y, -(*eye).z);
+    let matrix = glam::DMat4::look_at_rh(*eye, *at, *up);
+    gl::MultMatrixd(matrix.as_ref().as_ptr());
 }
 
 #[no_mangle]
@@ -46,39 +31,13 @@ pub unsafe extern "C" fn GLMatrix_ModeWV() {
 
 #[no_mangle]
 pub unsafe extern "C" fn GLMatrix_Mult(matrix: &mut Matrix) {
-    let m: &[f32; 16] = &matrix.m;
-    let transpose: [f32; 16] = [
-        m[0], m[4], m[8], m[12], m[1], m[5], m[9], m[13], m[2], m[6], m[10], m[14], m[3], m[7],
-        m[11], m[15],
-    ];
-    gl::MultMatrixf(transpose.as_ptr());
+    gl::MultMatrixf(matrix.as_ref().as_ptr());
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn GLMatrix_Perspective(fovy: f64, aspect: f64, z0: f64, z1: f64) {
-    let rads: f64 = std::f32::consts::PI as f64 * fovy / 360.0f64;
-    let cot: f64 = 1.0f64 / f64::tan(rads);
-    let dz: f64 = z1 - z0;
-    let nf: f64 = -2.0f64 * (z0 * z1) / dz;
-    let mut m: [f64; 16] = [
-        cot / aspect,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        cot,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        -(z0 + z1) / dz,
-        -1.0f64,
-        0.0,
-        0.0,
-        nf,
-        0.0,
-    ];
-    gl::MultMatrixd(m.as_mut_ptr());
+    let matrix = glam::DMat4::perspective_rh_gl(fovy, aspect, z0, z1);
+    gl::MultMatrixd(matrix.as_ref().as_ptr());
 }
 
 #[no_mangle]
@@ -99,37 +58,33 @@ pub unsafe extern "C" fn GLMatrix_PushClear() {
 
 #[no_mangle]
 pub unsafe extern "C" fn GLMatrix_Get() -> Option<Box<Matrix>> {
-    let mut matrixMode: gl::types::GLint = 0;
-    gl::GetIntegerv(gl::MATRIX_MODE, &mut matrixMode);
+    let mut matrix_mode: gl::types::GLint = 0;
+    gl::GetIntegerv(gl::MATRIX_MODE, &mut matrix_mode);
 
-    match matrixMode as u32 {
-        gl::MODELVIEW => {
-            matrixMode = gl::MODELVIEW_MATRIX as i32;
-        }
-        gl::PROJECTION => {
-            matrixMode = gl::PROJECTION_MATRIX as i32;
-        }
-        gl::COLOR | gl::TEXTURE | _ => return None,
-    }
+    let matrix_enum = match matrix_mode as u32 {
+        gl::MODELVIEW => gl::MODELVIEW_MATRIX,
+        gl::PROJECTION => gl::PROJECTION_MATRIX,
+        _ => return None,
+    };
 
-    let mut matrix: Box<Matrix> = Matrix_Identity();
-    gl::GetFloatv(matrixMode as gl::types::GLenum, matrix.m.as_mut_ptr());
-    Some(matrix)
+    let mut matrix = Matrix::IDENTITY;
+    gl::GetFloatv(matrix_enum, matrix.as_mut().as_mut_ptr());
+    Some(Box::new(matrix))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn GLMatrix_RotateX(angle: f64) {
-    gl::Rotated(angle, 1.0f64, 0.0f64, 0.0f64);
+    gl::Rotated(angle, 1.0, 0.0, 0.0);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn GLMatrix_RotateY(angle: f64) {
-    gl::Rotated(angle, 0.0f64, 1.0f64, 0.0f64);
+    gl::Rotated(angle, 0.0, 1.0, 0.0);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn GLMatrix_RotateZ(angle: f64) {
-    gl::Rotated(angle, 0.0f64, 0.0f64, 1.0f64);
+    gl::Rotated(angle, 0.0, 0.0, 1.0);
 }
 
 #[no_mangle]

--- a/engine/lib/phx/src/render/shader.rs
+++ b/engine/lib/phx/src/render/shader.rs
@@ -467,7 +467,7 @@ pub unsafe extern "C" fn Shader_SetMatrix(name: *const libc::c_char, value: &mut
     gl::UniformMatrix4fv(
         GetUniformIndex(current.as_mut(), name),
         1,
-        gl::TRUE,
+        gl::FALSE,
         value as *mut Matrix as *mut f32,
     );
 }
@@ -477,19 +477,19 @@ pub unsafe extern "C" fn Shader_SetMatrixT(name: *const libc::c_char, value: &mu
     gl::UniformMatrix4fv(
         GetUniformIndex(current.as_mut(), name),
         1,
-        gl::FALSE,
+        gl::TRUE,
         value as *mut Matrix as *mut f32,
     );
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Shader_ISetMatrix(index: i32, value: &mut Matrix) {
-    gl::UniformMatrix4fv(index, 1, gl::TRUE, value as *mut Matrix as *mut f32);
+    gl::UniformMatrix4fv(index, 1, gl::FALSE, value as *mut Matrix as *mut f32);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn Shader_ISetMatrixT(index: i32, value: &mut Matrix) {
-    gl::UniformMatrix4fv(index, 1, gl::FALSE, value as *mut Matrix as *mut f32);
+    gl::UniformMatrix4fv(index, 1, gl::TRUE, value as *mut Matrix as *mut f32);
 }
 
 #[no_mangle]

--- a/script/Systems/Overlay/GameView.lua
+++ b/script/Systems/Overlay/GameView.lua
@@ -232,9 +232,11 @@ function GameView:onUpdate(state)
         self.eyeLast:setv(eye)
     end
 
-    LTheoryRedux.audio:setListenerPos(
-        self.camera.pos,
-        self.camera.rot)
+    if LTheoryRedux.audio ~= nil then
+        LTheoryRedux.audio:setListenerPos(
+            self.camera.pos,
+            self.camera.rot)
+    end
 
     self.camera:pop()
 end


### PR DESCRIPTION
glam is a 3D math library we use in libphx for vectors. However, we're still using the original libphx matrix / quat math functions, and many of those are potentially hiding hidden bugs / inefficiencies / other issues, and are also unsafe as they rely on a lot of array indexing. It's also hard to maintain them without any unit tests, so this PR switches the implementation of them over to using glam equivalents, which are already maintained, fast and 100% tested.

The biggest notable semantic change is that matrices are now column-major (like OpenGL), rather then row-major (like Direct3D). This doesn't really change much in reality, because libphx was previously transposing it's row major matrices before passing them to shaders (which are column major), and now we just stop doing that and pass the matrices verbatim (see https://github.com/Limit-Theory-Redux/ltheory/pull/151/files#diff-f806f49bdb3e58ab633b5f5eb893cea3d3560ddbfa9a1587979c317cab0d8ba1 for where that change is).