### PR TITLE
refactor: prevent thruster fx being rendered in first person

### DIFF
--- a/script/GameObjects/Entities/Ship/Thruster.lua
+++ b/script/GameObjects/Entities/Ship/Thruster.lua
@@ -54,6 +54,9 @@ function Thruster:render(state)
     if state.mode == BlendMode.Additive then
         local a = math.abs(self.activation)
         if a < 1e-3 then return end
+        if self.parent:getOwner():getControlling() == GameState.player.currentShip and GameState.player.currentCamera == Enums.CameraMode.FirstPerson then
+            return
+        end
         local shader = Cache.Shader('billboard/axis', 'effect/thruster')
         shader:start()
         Shader.SetFloat('alpha', a)

--- a/script/GameObjects/Entities/Ship/Thruster.lua
+++ b/script/GameObjects/Entities/Ship/Thruster.lua
@@ -52,11 +52,12 @@ end
 
 function Thruster:render(state)
     if state.mode == BlendMode.Additive then
-        local a = math.abs(self.activation)
-        if a < 1e-3 then return end
         if self.parent:getOwner():getControlling() == GameState.player.currentShip and GameState.player.currentCamera == Enums.CameraMode.FirstPerson then
             return
         end
+
+        local a = math.abs(self.activation)
+        if a < 1e-3 then return end
         local shader = Cache.Shader('billboard/axis', 'effect/thruster')
         shader:start()
         Shader.SetFloat('alpha', a)


### PR DESCRIPTION
The thruster effect was displayed on the first person camera sometimes occluding it when flying backwards.