### PR TITLE
Render build version & adjust WIP text

### DIFF
--- a/script/States/Application.lua
+++ b/script/States/Application.lua
@@ -250,7 +250,7 @@ function Application:onFrame()
                 'NovaRound',
                 "Build " .. Config.gameVersion,
                 12,
-                5, self.resY - 20, 40, 20,
+                4, self.resY - 20, 40, 20,
                 0.75, 0.75, 0.75, 0.75,
                 0, 0.5
             )

--- a/script/States/Application.lua
+++ b/script/States/Application.lua
@@ -238,10 +238,18 @@ function Application:onFrame()
     else
         UI.DrawEx.TextAdditive(
             'NovaRound',
-            "EXPERIMENTAL BUILD - NOT FINAL!",
+            "WORK IN PROGRESS",
             20,
-            self.resX / 2 - 24, 62, 40, 20,
-            1, 1, 1, 1,
+            self.resX / 2 - 24, 50, 40, 20,
+            0.65, 0.65, 0.65, 0.65,
+            0.5, 0.5
+        )
+        UI.DrawEx.TextAdditive(
+            'NovaRound',
+            "Build " .. Config.gameVersion,
+            16,
+            self.resX / 2 - 24, 70, 40, 20,
+            0.65, 0.65, 0.65, 0.65,
             0.5, 0.5
         )
     end

--- a/script/States/Application.lua
+++ b/script/States/Application.lua
@@ -240,18 +240,21 @@ function Application:onFrame()
             'NovaRound',
             "WORK IN PROGRESS",
             20,
-            self.resX / 2 - 24, 50, 40, 20,
-            0.65, 0.65, 0.65, 0.65,
+            self.resX / 2, 50, 40, 20,
+            0.75, 0.75, 0.75, 0.75,
             0.5, 0.5
         )
-        UI.DrawEx.TextAdditive(
-            'NovaRound',
-            "Build " .. Config.gameVersion,
-            16,
-            self.resX / 2 - 24, 70, 40, 20,
-            0.65, 0.65, 0.65, 0.65,
-            0.5, 0.5
-        )
+
+        if GameState:GetCurrentState() == Enums.GameStates.InGame then
+            UI.DrawEx.TextAdditive(
+                'NovaRound',
+                "Build " .. Config.gameVersion,
+                12,
+                5, self.resY - 20, 40, 20,
+                0.75, 0.75, 0.75, 0.75,
+                0, 0.5
+            )
+        end
     end
 
     if GameState:GetCurrentState() ~= Enums.GameStates.MainMenu then

--- a/script/States/Application.lua
+++ b/script/States/Application.lua
@@ -206,7 +206,7 @@ function Application:onFrame()
                 'Exo2',
                 "[B] Generate new star system",
                 20,
-                self.resX / 2, self.resY - 150, 40, 20,
+                self.resX / 2 - 20, self.resY - 150, 40, 20,
                 1, 1, 1, 1,
                 0.5, 0.5
             )
@@ -214,25 +214,25 @@ function Application:onFrame()
                 'Exo2',
                 "[H] Speed up time",
                 20,
-                self.resX / 2, self.resY - 125, 40, 20,
+                self.resX / 2 - 20, self.resY - 125, 40, 20,
                 1, 1, 1, 1,
-                0.5, 1
+                0.5, 0.5
             )
             UI.DrawEx.TextAdditive(
                 'Exo2',
                 "[K] Metrics display",
                 20,
-                self.resX / 2, self.resY - 100, 40, 20,
+                self.resX / 2 - 20, self.resY - 100, 40, 20,
                 1, 1, 1, 1,
-                0.5, 1
+                0.5, 0.5
             )
             UI.DrawEx.TextAdditive(
                 'Exo2',
                 "[V] Toggle hints",
                 20,
-                self.resX / 2, self.resY - 75, 40, 20,
+                self.resX / 2 - 20, self.resY - 75, 40, 20,
                 1, 1, 1, 1,
-                0.5, 1
+                0.5, 0.5
             )
         end
     else
@@ -240,7 +240,7 @@ function Application:onFrame()
             'NovaRound',
             "WORK IN PROGRESS",
             20,
-            self.resX / 2, 50, 40, 20,
+            self.resX / 2 - 20, 50, 40, 20,
             0.75, 0.75, 0.75, 0.75,
             0.5, 0.5
         )


### PR DESCRIPTION
- Changes the kinda aggressive sounding `EXPERIMENTAL BUILD - NOT FINAL!` to `WORK IN PROGRESS` :D 
- Renders the build number / game version on the bottom left
- Makes the text a bit transparent
- Changes are for the upcoming nightly release change #180 

![2023-11-17 02](https://github.com/Limit-Theory-Redux/ltheory/assets/76592751/1d8c4777-ca66-4efe-9bb6-4b00995dd903)
