### PR TITLE
Ensure that release is not created as a draft

### DIFF
--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -166,4 +166,5 @@ jobs:
           body: "Build log: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           tag_name: "latest"
           prerelease: true
+          draft: false
           files: ./*.zip


### PR DESCRIPTION
- noticed that this happens yesterday if releasing as a prerelease