### PR TITLE
Three Fixes

### DIFF
--- a/script/GameObjects/Entities/Ship/Thruster.lua
+++ b/script/GameObjects/Entities/Ship/Thruster.lua
@@ -52,9 +52,10 @@ end
 
 function Thruster:render(state)
     if state.mode == BlendMode.Additive then
-        if self.parent:getOwner():getControlling() == GameState.player.currentShip and GameState.player.currentCamera == Enums.CameraMode.FirstPerson then
-            return
-        end
+-- This test (added to improve performance?) needs to be rethought as it is causing a crash when any ship -- player or NPC -- is destroyed.
+--        if self.parent:getOwner():getControlling() == GameState.player.currentShip and GameState.player.currentCamera == Enums.CameraMode.FirstPerson then
+--            return
+--        end
 
         local a = math.abs(self.activation)
         if a < 1e-3 then return end

--- a/script/GameObjects/Entities/Ship/Thruster.lua
+++ b/script/GameObjects/Entities/Ship/Thruster.lua
@@ -52,10 +52,12 @@ end
 
 function Thruster:render(state)
     if state.mode == BlendMode.Additive then
+--[[
 -- This test (added to improve performance?) needs to be rethought as it is causing a crash when any ship -- player or NPC -- is destroyed.
---        if self.parent:getOwner():getControlling() == GameState.player.currentShip and GameState.player.currentCamera == Enums.CameraMode.FirstPerson then
---            return
---        end
+        if self.parent:getOwner():getControlling() == GameState.player.currentShip and GameState.player.currentCamera == Enums.CameraMode.FirstPerson then
+            return
+        end
+]]--
 
         local a = math.abs(self.activation)
         if a < 1e-3 then return end

--- a/script/States/App/LTheoryRedux.lua
+++ b/script/States/App/LTheoryRedux.lua
@@ -132,8 +132,6 @@ function LTheoryRedux:onInput()
         end
 
         if InputInstance:isPressed(Button.KeyboardF) then
-            GameState:SetState(Enums.GameStates.InGame)
-
             -- Insert the game view into the application canvas to make it visible
             self.gameView = Systems.Overlay.GameView(self.player, self.audio)
             GameState.render.gameView = self.gameView
@@ -144,6 +142,8 @@ function LTheoryRedux:onInput()
                     :add(Systems.Controls.Controls.MasterControl(self.gameView, self.player))
                 )
             self.gameView:setCameraMode(Enums.CameraMode.FirstPerson)
+
+            GameState:SetState(Enums.GameStates.InGame)
         end
     end
 end
@@ -422,11 +422,6 @@ function LTheoryRedux:showGameLogo()
 
     Gui:image(self.logo) -- draw the LTR logo on top of the canvas
     Gui:setPercentSize(76.0 * scaleFactor / scaleFactorX, 24.3 * scaleFactor / scaleFactorY)
-    Gui:setAlignment(AlignHorizontal.Center, AlignVertical.Center)
-end
-
-function LTheoryRedux:showShipCreationHint()
-    Gui:textEx(Cache.Font('Exo2', 32), '[B]: Random Ship | [F]: Spawn', 1.0, 1.0, 1.0, 1.0)
     Gui:setAlignment(AlignHorizontal.Center, AlignVertical.Center)
 end
 

--- a/script/States/Application.lua
+++ b/script/States/Application.lua
@@ -43,12 +43,12 @@ function Application:appInit()
     WindowInstance:setCenteredPosition()
     WindowInstance:setSize(self.resX, self.resY)
 
-    self.audio                  = Audio.Create()
-    self.audiofx                = Audio.Create()
+    self.audio   = Audio.Create()
+    self.audiofx = Audio.Create()
 
     GameState.render.gameWindow = WindowInstance
 
-    self.exit                   = false
+    self.exit = false
 
     WindowInstance:setPresentMode(GameState.render.presentMode)
 

--- a/script/States/ApplicationBindings.lua
+++ b/script/States/ApplicationBindings.lua
@@ -24,7 +24,7 @@ local self = {
     CameraOrbit       = Button.KeyboardF3,
     Exit              = Button.SystemExit, -- Modifier.Ctrl + Button.W or Modifier.Alt + Button.Q
 
-    All               = Control.Or(
+    All = Control.Or(
             Control.Key(Button.KeyboardA),
             Control.Key(Button.KeyboardB),
             Control.Key(Button.KeyboardC),

--- a/script/Systems/Controls/Bindings/ShipBindings.lua
+++ b/script/Systems/Controls/Bindings/ShipBindings.lua
@@ -1,19 +1,19 @@
 local Control = require('Systems.Controls.Control')
 
 local self = {
-    ThrustX           = Control.Or(
+    ThrustX = Control.Or(
         Control.Pair(
             Control.Key(Button.KeyboardD),
             Control.Key(Button.KeyboardA)),
         Control.GamepadAxis(Button.GamepadLeftStickX)),
 
-    ThrustZ           = Control.Or(
+    ThrustZ = Control.Or(
         Control.Pair(
             Control.Key(Button.KeyboardW),
             Control.Key(Button.KeyboardS)),
         Control.GamepadAxis(Button.GamepadLeftStickY)),
 
-    ThrustY           = Control.Or(
+    ThrustY = Control.Or(
         Control.Pair(
             Control.Key(Button.KeyboardSpace),
             Control.Ctrl()),
@@ -21,7 +21,7 @@ local self = {
             Control.GamepadAxis(Button.GamepadDPadUp),
             Control.GamepadAxis(Button.GamepadDPadDown))),
 
-    Roll              = Control.Or(
+    Roll = Control.Or(
         Control.Pair(
             Control.Key(Button.KeyboardE),
             Control.Key(Button.KeyboardQ)),
@@ -29,43 +29,43 @@ local self = {
             Control.GamepadButton(Button.GamepadRightTrigger2),
             Control.GamepadButton(Button.GamepadLeftTrigger2))),
 
-    Yaw               = Control.Or(
+    Yaw = Control.Or(
         Control.MouseX(),
         Control.GamepadAxis(Button.GamepadRightStickX)),
 
-    Pitch             = Control.Or(
+    Pitch = Control.Or(
         Control.MouseY():invert(),
         Control.GamepadAxis(Button.GamepadRightStickY):invert()),
 
-    Boost             = Control.Or(
+    Boost = Control.Or(
         Control.Shift(),
         Control.GamepadAxis(Button.GamepadLeftTrigger)),
 
-    Fire              = Control.Or(
+    Fire = Control.Or(
         Control.MouseButton(Button.MouseLeft),
         Control.GamepadAxis(Button.GamepadRightTrigger)),
 
-    LockTarget        = Control.Or(
+    LockTarget = Control.Or(
             Control.Key(Button.KeyboardT),
             Control.GamepadButton(Button.GamepadWest))
         :delta(),
 
-    ClearTarget       = Control.Or(
+    ClearTarget = Control.Or(
             Control.Key(Button.KeyboardG),
             Control.GamepadButton(Button.GamepadEast))
         :delta(),
 
-    NearestTarget     = Control.Or(
+    NearestTarget = Control.Or(
             Control.Key(Button.KeyboardN),
             Control.GamepadButton(Button.GamepadWest))
         :delta(),
 
-    Dock              = Control.Or(
+    Dock = Control.Or(
             Control.Key(Button.KeyboardF),
             Control.GamepadButton(Button.GamepadNorth))
         :delta(),
 
-    Undock            = Control.Or(
+    Undock = Control.Or(
             Control.Key(Button.KeyboardJ),
             Control.GamepadButton(Button.GamepadSouth))
         :delta(),

--- a/script/Systems/SFX/MusicPlayer.lua
+++ b/script/Systems/SFX/MusicPlayer.lua
@@ -23,12 +23,15 @@ end
 
 function MusicPlayer:LoadEffects()
     -- *** TEMP: Audio FX test START ***
+
+    --[[ -- Pulse weapon firing sound effect temporarily commented out until setVolume() is working
     Config.audio.pulseFire = SFXObject:Create {
         name = Config.audio.pulseFireName,
         path = Config.paths.soundEffects .. Config.audio.pulseFireName,
         volume = 0.0,
         isLooping = false
     }
+    ]]
 
     Config.audio.fxSensors = SFXObject:Create {
         name = Config.audio.fxSensorsName,

--- a/script/Systems/Universe/Universe.lua
+++ b/script/Systems/Universe/Universe.lua
@@ -114,7 +114,9 @@ function Universe:CreateShip(system, pos, shipObject)
     ship:setName(shipObject.shipName)
 
     -- Insert ship into this star system
-    local spawnPosition = pos or Config.gen.origin
+    local spawnPosition = ship:getPos() -- use semi-randomly generated position from spawnShip()
+    if pos then spawnPosition = pos end -- unless a position was explicitly provided, in which case use that position
+
     ship:setPos(spawnPosition)
     ship:setFriction(shipObject.friction)
     ship:setSleepThreshold(shipObject.sleepThreshold[1], shipObject.sleepThreshold[2])


### PR DESCRIPTION
1. Prevent crash in Thruster.lua when any ship (player or NPC) is destroyed. A test was added recently to Thruster:render() to not display thrusters if the player's ship was in first-person mode. This test was referencing a nil object when any ship is destroyed, causing a crash to desktop. This test has been temporarily commented out until it can be refined if necessary.

2. Prevent crash when "B" to spawn a new player ship is pressed more than one time. The recent addition to enable "B" to generate multiple Solo sized player ships before entering a game universe, and "F" to spawn the created player ship, worked only if "B" was pressed once. If "B" was pressed twice or more, then the ship was spawned, a hard crash would occur in the sensor display section of HUD.lua because the position of the newly spawned ship was too close to zero to be normalized. This has been corrected by telling Universe:CreateShip() to use the ship position generated in System:spawnShip().

3. Not a crash, but an incredibly loud noise when first displaying a new universe. Currently setVolume isn't working, so the pulseFire variable was being set to nil to prevent the sound of pulse weapons firing from being played. This setting was changed in MusicPlayer.lua, causing the pulseFire sound to be unexpectedly played at maximum volume at universe start-up time, and to generate "command queue full" messages at high speed during play. This has been temporarily resolved by commenting out the section of code in MusicPlayer.lua that generates a non-nil value for the pulseFire variable.