### PR TITLE
Add support for out parameters, boxed types, and returning an mutable optional ref. Fix some mismatches in the C FFI.

### DIFF
--- a/engine/lib/internal/src/memory.rs
+++ b/engine/lib/internal/src/memory.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 #[inline]
 pub unsafe extern "C" fn MemAlloc(size: usize) -> *mut libc::c_void {
     libc::malloc(size)

--- a/engine/lib/luajit-ffi-gen/README.md
+++ b/engine/lib/luajit-ffi-gen/README.md
@@ -302,10 +302,11 @@ Under the hood proc macro on the `enum` block instead of generating ***.lua** sc
 - **with_impl** \[bool, default = false]: specify if enum has connected implementation block.
 
 ### bind
-- **name** [string] - set user defined name of the function
+- **name** [string] - set user defined name of the function.
 - **role** [enum: constructor, to_string] - set function role.
-- **constructor** - function won't appear in the metatype section
-- **to_string** - will generate a binding in the metatype section
+- **constructor** - function won't appear in the metatype section.
+- **to_string** - will generate a binding in the metatype section.
+- **out_param** - return value via an out parameter at the end of the function signature.
 
 ## Macro expansion
 

--- a/engine/lib/luajit-ffi-gen/src/args/bind_args.rs
+++ b/engine/lib/luajit-ffi-gen/src/args/bind_args.rs
@@ -27,6 +27,7 @@ pub struct BindArgs {
     name: Option<String>,
     role: Option<BindMethodRole>,
     lua_ffi: bool,
+    out_param: bool,
 }
 
 impl Default for BindArgs {
@@ -35,6 +36,7 @@ impl Default for BindArgs {
             name: None,
             role: None,
             lua_ffi: true,
+            out_param: false,
         }
     }
 }
@@ -60,6 +62,12 @@ impl BindArgs {
     /// Default: true
     pub fn gen_lua_ffi(&self) -> bool {
         self.lua_ffi
+    }
+
+    /// Specify if the return value should be sent via an &mut out parameter.
+    /// Default: false
+    pub fn gen_out_param(&self) -> bool {
+        self.out_param
     }
 }
 
@@ -101,10 +109,22 @@ impl Parse for BindArgs {
                         ));
                     }
                 }
+                "out_param" => {
+                    if let Lit::Bool(val) = &param.value.lit {
+                        res.out_param = val.value();
+                    } else {
+                        return Err(Error::new(
+                            param.value.span(),
+                            "expected 'out_param' bind attribute parameter as boolean literal",
+                        ));
+                    }
+                }
                 _ => {
                     return Err(Error::new(
                         param.name.span(),
-                        format!("expected bind attribute parameter: name, role, lua_ffi"),
+                        format!(
+                            "expected bind attribute parameter: name, role, lua_ffi, out_param"
+                        ),
                     ))
                 }
             }

--- a/engine/lib/luajit-ffi-gen/src/impl_item/generate.rs
+++ b/engine/lib/luajit-ffi-gen/src/impl_item/generate.rs
@@ -74,7 +74,7 @@ impl ImplInfo {
 
         let ret_token = if method.bind_args.gen_out_param() || method.ret.is_none() {
             quote! {}
-        } else  {
+        } else {
             let ret = method.ret.as_ref().unwrap();
             let ty_token = wrap_ret_type(&self.name, &ret, false);
 

--- a/engine/lib/luajit-ffi-gen/src/impl_item/generate.rs
+++ b/engine/lib/luajit-ffi-gen/src/impl_item/generate.rs
@@ -61,18 +61,24 @@ impl ImplInfo {
             quote! {}
         };
 
-        let param_tokens: Vec<_> = method
+        let mut param_tokens: Vec<_> = method
             .params
             .iter()
             .map(|param| wrap_param(&self.name, param))
             .collect();
 
-        let ret_token = if let Some(ty) = &method.ret {
-            let ty_token = wrap_ret_type(&self.name, &ty);
+        if method.bind_args.gen_out_param() && method.ret.is_some() {
+            let return_ty_token = wrap_ret_type(&self.name, method.ret.as_ref().unwrap(), true);
+            param_tokens.push(quote! { out: &mut #return_ty_token })
+        }
+
+        let ret_token = if method.bind_args.gen_out_param() || method.ret.is_none() {
+            quote! {}
+        } else  {
+            let ret = method.ret.as_ref().unwrap();
+            let ty_token = wrap_ret_type(&self.name, &ret, false);
 
             quote! { -> #ty_token }
-        } else {
-            quote! {}
         };
 
         let func_ident_str = format!("{func_ident}");
@@ -153,7 +159,7 @@ fn wrap_type(self_name: &str, ty: &TypeInfo) -> TokenStream {
     }
 }
 
-fn wrap_ret_type(self_name: &str, ty: &TypeInfo) -> TokenStream {
+fn wrap_ret_type(self_name: &str, ty: &TypeInfo, never_box: bool) -> TokenStream {
     match &ty.variant {
         TypeVariant::Str | TypeVariant::String | TypeVariant::CString => {
             quote! { *const libc::c_char }
@@ -172,7 +178,7 @@ fn wrap_ret_type(self_name: &str, ty: &TypeInfo) -> TokenStream {
                 } else {
                     quote! { *const #ty_ident }
                 }
-            } else if is_copyable {
+            } else if is_copyable || never_box {
                 quote! { #ty_ident }
             } else if ty.is_mutable {
                 quote! { *mut #ty_ident }
@@ -224,11 +230,10 @@ fn gen_func_body(self_ident: &Ident, method: &MethodInfo) -> TokenStream {
                         } else {
                             quote! { #name_accessor }
                         }
-                    } else if param.ty.is_reference{
+                    } else if param.ty.is_reference || param.ty.is_boxed {
                         quote! { #name_accessor }
                     } else {
-                        // FIXME: Boxed type. into_inner is nightly only. Alternative Option::unwrap
-                        quote! { #name_accessor.into_inner() }
+                        quote! { *#name_accessor }
                     }
                 },
                 _ => {
@@ -267,9 +272,16 @@ fn gen_func_body(self_ident: &Ident, method: &MethodInfo) -> TokenStream {
         };
 
         let method_call = if ty.is_option {
-            quote! {
-                #method_call
-                let Some(__res__) = __res__ else { return std::ptr::null(); };
+            if ty.is_mutable {
+                quote! {
+                    #method_call
+                    let Some(__res__) = __res__ else { return std::ptr::null_mut(); };
+                }
+            } else {
+                quote! {
+                    #method_call
+                    let Some(__res__) = __res__ else { return std::ptr::null(); };
+                }
             }
         } else {
             method_call
@@ -293,7 +305,7 @@ fn gen_func_body(self_ident: &Ident, method: &MethodInfo) -> TokenStream {
                     } else {
                         gen_buffered_ret(&type_ident)
                     }
-                } else if is_copyable {
+                } else if is_copyable || method.bind_args.gen_out_param() {
                     if ty.is_reference {
                         quote! { *__res__ }
                     } else {
@@ -303,9 +315,10 @@ fn gen_func_body(self_ident: &Ident, method: &MethodInfo) -> TokenStream {
                     quote! { __res__ as *mut #type_ident }
                 } else if ty.is_reference {
                     quote! { __res__ as *const #type_ident }
-                } else {
-                    // Do boxing
+                } else if !ty.is_boxed {
                     quote! { __res__.into() }
+                } else {
+                    quote! { __res__ }
                 }
             }
             _ => {
@@ -319,9 +332,16 @@ fn gen_func_body(self_ident: &Ident, method: &MethodInfo) -> TokenStream {
             }
         };
 
-        quote! {
-            #method_call
-            #return_item
+        if method.bind_args.gen_out_param() {
+            quote! {
+                #method_call
+                *out = #return_item;
+            }
+        } else {
+            quote! {
+                #method_call
+                #return_item
+            }
         }
     } else {
         quote! {

--- a/engine/lib/luajit-ffi-gen/src/impl_item/parse.rs
+++ b/engine/lib/luajit-ffi-gen/src/impl_item/parse.rs
@@ -233,7 +233,9 @@ fn parse_type(ty: &Type) -> Result<TypeInfo> {
                 if counter > 1 {
                     return Err(Error::new(
                         type_path.span(),
-                        format!("a type can't be nested within more than one of: Box, Option, Result."),
+                        format!(
+                            "a type can't be nested within more than one of: Box, Option, Result."
+                        ),
                     ));
                 }
 

--- a/engine/lib/luajit-ffi-gen/src/impl_item/parse.rs
+++ b/engine/lib/luajit-ffi-gen/src/impl_item/parse.rs
@@ -161,15 +161,6 @@ fn parse_params<'a>(
                     ));
                 }
 
-                if let TypeVariant::Custom(ty_name) = &ty.variant {
-                    if !ty.is_reference && !TypeInfo::is_copyable(&ty_name) {
-                        return Err(Error::new(
-                            pat_type.ty.span(),
-                            "by value non-copyable parameters are not supported",
-                        ));
-                    }
-                }
-
                 let param_info = ParamInfo { name, ty };
 
                 params_info.push(param_info);
@@ -216,7 +207,7 @@ fn parse_type(ty: &Type) -> Result<TypeInfo> {
                 type_info.is_result = true;
 
                 return Ok(type_info);
-            } else if type_name == "Option" {
+            } else if type_name == "Option" || type_name == "Box" {
                 if generics.len() != 1 {
                     return Err(Error::new(
                         type_path.span(),
@@ -229,21 +220,28 @@ fn parse_type(ty: &Type) -> Result<TypeInfo> {
 
                 let mut type_info = parse_type(&generics[0])?;
 
+                let mut counter = 0;
                 if type_info.is_option {
-                    return Err(Error::new(
-                        type_path.span(),
-                        format!("nested option is not supported"),
-                    ));
+                    counter += 1;
                 }
-
                 if type_info.is_result {
+                    counter += 1;
+                }
+                if type_info.is_boxed {
+                    counter += 1;
+                }
+                if counter > 1 {
                     return Err(Error::new(
                         type_path.span(),
-                        format!("result nested in option is not supported"),
+                        format!("a type can't be nested within more than one of: Box, Option, Result."),
                     ));
                 }
 
-                type_info.is_option = true;
+                if type_name == "Option" {
+                    type_info.is_option = true;
+                } else {
+                    type_info.is_boxed = true;
+                }
 
                 return Ok(type_info);
             }
@@ -255,6 +253,7 @@ fn parse_type(ty: &Type) -> Result<TypeInfo> {
                     is_option: false,
                     is_reference: false,
                     is_mutable: false,
+                    is_boxed: false,
                     variant,
                 }
             } else {
@@ -263,6 +262,7 @@ fn parse_type(ty: &Type) -> Result<TypeInfo> {
                     is_option: false,
                     is_reference: false,
                     is_mutable: false,
+                    is_boxed: false,
                     // TODO: are we going to support full path to type? I.e. std::path::PathBuf
                     variant: TypeVariant::Custom(type_name),
                 }

--- a/engine/lib/luajit-ffi-gen/src/impl_item/type_info.rs
+++ b/engine/lib/luajit-ffi-gen/src/impl_item/type_info.rs
@@ -169,22 +169,6 @@ pub enum TypeVariant {
 }
 
 impl TypeVariant {
-    pub fn is_custom(&self) -> bool {
-        matches!(self, Self::Custom(_))
-    }
-
-    #[allow(dead_code)]
-    pub fn is_str(&self) -> bool {
-        matches!(self, Self::Str)
-    }
-
-    pub fn is_string(&self) -> bool {
-        match self {
-            Self::Str | Self::String | Self::CString => true,
-            _ => false,
-        }
-    }
-
     pub fn from_str(type_name: &str) -> Option<Self> {
         let res = match type_name {
             "bool" => Self::Bool,

--- a/engine/lib/luajit-ffi-gen/src/impl_item/type_info.rs
+++ b/engine/lib/luajit-ffi-gen/src/impl_item/type_info.rs
@@ -91,20 +91,15 @@ impl TypeInfo {
                 } else {
                     format!("cstr")
                 }
-            },
+            }
             TypeVariant::Custom(ty_name) => {
-                let ty_ident = if self.is_self() {
-                    self_name
-                } else {
-                    ty_name
-                };
+                let ty_ident = if self.is_self() { self_name } else { ty_name };
 
-                let ffi_ty_name =
-                    RUST_TO_LUA_TYPE_MAP
-                        .iter()
-                        .find(|(r_ty, _)| *r_ty == ty_name)
-                        .map(|(_, l_ty)| l_ty.to_string())
-                        .unwrap_or(ty_ident.to_string());
+                let ffi_ty_name = RUST_TO_LUA_TYPE_MAP
+                    .iter()
+                    .find(|(r_ty, _)| *r_ty == ty_name)
+                    .map(|(_, l_ty)| l_ty.to_string())
+                    .unwrap_or(ty_ident.to_string());
 
                 if self.is_option {
                     if self.is_mutable {
@@ -124,10 +119,10 @@ impl TypeInfo {
                         format!("{ffi_ty_name}*")
                     }
                 }
-            },
+            }
             _ => {
                 let ty_ident = self.variant.as_ffi_string();
-    
+
                 if self.is_option {
                     // All options are sent by pointer
                     if self.is_mutable {

--- a/engine/lib/luajit-ffi-gen/tests/test_impl.rs
+++ b/engine/lib/luajit-ffi-gen/tests/test_impl.rs
@@ -192,6 +192,7 @@ fn test_functions() {
 
     MyStruct_SetData(&mut ms2, &Data::new(2));
     assert_eq!(MyStruct_GetData(&ms2).val, 2);
+    assert_eq!(unsafe { (*MyStruct_GetOptData(&ms2)).val }, 2);
 
     MyStruct_TakeData(&mut ms2, Box::new(Data::new(4)));
     let mut returned_data = Data::new(0);
@@ -204,7 +205,6 @@ fn test_functions() {
     let val = MyStruct_RetResVal();
     assert_eq!(val, 42);
 }
-
 
 #[test]
 fn test_copyable_param() {

--- a/engine/lib/luajit-ffi-gen/tests/test_impl.rs
+++ b/engine/lib/luajit-ffi-gen/tests/test_impl.rs
@@ -6,7 +6,13 @@ use crate::utils::*;
 
 #[derive(Default, Clone)]
 pub struct Data {
-    pub val: bool,
+    pub val: u32,
+}
+
+impl Data {
+    fn new(val: u32) -> Data {
+        Data { val }
+    }
 }
 
 #[derive(Default)]
@@ -52,15 +58,31 @@ impl MyStruct {
 
     pub fn set_data(&mut self, val: &Data) {
         self.val_data = val.clone();
-        self.val_data.val = true;
+    }
+
+    pub fn take_data(&mut self, val: Data) {
+        self.val_data = val;
+    }
+
+    pub fn take_boxed_data(&mut self, val: Box<Data>) {
+        self.val_data = *val;
     }
 
     pub fn get_data(&self) -> Data {
         self.val_data.clone()
     }
 
+    #[bind(out_param = true)]
+    pub fn get_data_via_out_param(&self) -> Data {
+        self.val_data.clone()
+    }
+
     pub fn get_data_ref(&self) -> &Data {
         &self.val_data
+    }
+
+    pub fn get_boxed_data(&self) -> Box<Data> {
+        Box::new(self.val_data.clone())
     }
 
     pub fn get_data_mut(&mut self) -> &mut Data {
@@ -125,13 +147,21 @@ fn test_impl() {
     MyStruct_FUNC3();
 
     MyStruct_SetU32(&mut ms2, 33);
-    assert_eq!(MyStruct_GetU32(&mut ms2), 33);
+    assert_eq!(MyStruct_GetU32(&ms2), 33);
 
     MyStruct_SetF32(&mut ms2, 33.0);
-    assert_eq!(MyStruct_GetF32(&mut ms2), 33.0);
+    assert_eq!(MyStruct_GetF32(&ms2), 33.0);
 
-    MyStruct_SetData(&mut ms2, &Data::default());
-    assert!(MyStruct_GetData(&mut ms2).val);
+    MyStruct_SetData(&mut ms2, &Data::new(2));
+    assert_eq!(MyStruct_GetData(&ms2).val, 2);
+
+    MyStruct_TakeData(&mut ms2, Box::new(Data::new(4)));
+    let mut returned_data = Data::new(0);
+    MyStruct_GetDataViaOutParam(&ms2, &mut returned_data);
+    assert_eq!(returned_data.val, 4);
+
+    MyStruct_TakeBoxedData(&mut ms2, Box::new(Data::new(6)));
+    assert_eq!(MyStruct_GetBoxedData(&ms2).val, 6);
 
     let val = MyStruct_RetResVal();
     assert_eq!(val, 42)

--- a/engine/lib/phx/script/ffi_gen/Directory.lua
+++ b/engine/lib/phx/script/ffi_gen/Directory.lua
@@ -16,14 +16,14 @@ function Loader.defineType()
 
     do -- C Definitions
         ffi.cdef [[
-            void       Directory_Free        (Directory*);
-            Directory* Directory_Open        (cstr path);
-            cstr       Directory_GetNext     (Directory*);
-            bool       Directory_Change      (cstr cwd);
-            bool       Directory_Create      (cstr path);
-            cstr       Directory_GetCurrent  ();
-            cstr       Directory_GetPrefPath (cstr org, cstr app);
-            bool       Directory_Remove      (cstr path);
+            void             Directory_Free        (Directory*);
+            Directory const* Directory_Open        (cstr path);
+            cstr             Directory_GetNext     (Directory*);
+            bool             Directory_Change      (cstr cwd);
+            bool             Directory_Create      (cstr path);
+            cstr             Directory_GetCurrent  ();
+            cstr             Directory_GetPrefPath (cstr org, cstr app);
+            bool             Directory_Remove      (cstr path);
         ]]
     end
 


### PR DESCRIPTION
Out parameters are used quite often in the Physics code, so I decided to add support in luajit-ffi-gen rather than rewrite the Lua code.

This PR also fixes the annoying snake case warning generated when compiling `memory.rs`, and I fixed a few mismatches in the C FFI such as:
* When returning an option of a non-copyable type, like `Directory_Open`
* When returning a non-copyable type, the FFI was missing the `*`.

As both `as_ffi_string()` in `type_info.rs` and `wrap_type` in `generate.rs` are supposed to be equivalent to each other, I rewrote `as_ffi_string()` by taking the implementation of `wrap_type` and changing the Rust types to C. I find it much easier to follow now.

Generated `My_Struct.lua` from `test_impl.rs`, to show what the new features look like:
```lua
-- My_Struct -------------------------------------------------------------------
local Loader = {}

function Loader.declareType()
    ffi.cdef [[
        typedef struct My_Struct {} My_Struct;
    ]]

    return 1, 'My_Struct'
end

function Loader.defineType()
    local ffi = require('ffi')
    local libphx = require('libphx').lib
    local My_Struct

    do -- C Definitions
        ffi.cdef [[
            void          My_Struct_Func1                  (My_Struct const*);
            void          My_Struct_Func2                  (My_Struct*);
            void          My_Struct_FUNC3                  ();
            void          My_Struct_SetU32                 (My_Struct*, uint32 val);
            uint32        My_Struct_GetU32                 (My_Struct const*);
            void          My_Struct_SetF32                 (My_Struct*, float val);
            float         My_Struct_GetF32                 (My_Struct const*);
            void          My_Struct_SetStr                 (My_Struct*, cstr val);
            cstr          My_Struct_GetStr                 (My_Struct const*);
            void          My_Struct_SetData                (My_Struct*, Data const* val);
            void          My_Struct_TakeData               (My_Struct*, Data* val);
            void          My_Struct_TakeBoxedData          (My_Struct*, Data* val);
            Data*         My_Struct_GetData                (My_Struct const*);
            void          My_Struct_GetDataViaOutParam     (My_Struct const*, Data* out);
            Data const*   My_Struct_GetDataRef             (My_Struct const*);
            Data*         My_Struct_GetBoxedData           (My_Struct const*);
            Data*         My_Struct_GetDataMut             (My_Struct*);
            void          My_Struct_SetOpt                 (My_Struct*, uint32 const* val);
            uint32 const* My_Struct_GetOptU32              (My_Struct const*);
            Data const*   My_Struct_GetOptData             (My_Struct const*);
            void          My_Struct_SetOptRef              (My_Struct*, uint32 const* val);
            void          My_Struct_SetOptMut              (My_Struct*, uint32* val);
            uint8         My_Struct_RetResVal              ();
            uint8         My_Struct_RetResErr              ();
            uint8 const*  My_Struct_RetResOptVal           ();
            void          My_Struct_SetCopyable            (My_Struct*, WindowPos c);
            void          My_Struct_SetCopyableByRef       (My_Struct*, WindowPos const* c);
            void          My_Struct_SetCopyableByMutRef    (My_Struct*, WindowPos* c);
            WindowPos     My_Struct_GetCopyable            (My_Struct const*);
            void          My_Struct_GetCopyableViaOutParam (My_Struct const*, WindowPos* out);
            WindowPos     My_Struct_GetBoxedCopyable       (My_Struct const*);
        ]]
    end

    do -- Global Symbol Table
        My_Struct = {
            Func1                  = libphx.My_Struct_Func1,
            Func2                  = libphx.My_Struct_Func2,
            FUNC3                  = libphx.My_Struct_FUNC3,
            SetU32                 = libphx.My_Struct_SetU32,
            GetU32                 = libphx.My_Struct_GetU32,
            SetF32                 = libphx.My_Struct_SetF32,
            GetF32                 = libphx.My_Struct_GetF32,
            SetStr                 = libphx.My_Struct_SetStr,
            GetStr                 = libphx.My_Struct_GetStr,
            SetData                = libphx.My_Struct_SetData,
            TakeData               = libphx.My_Struct_TakeData,
            TakeBoxedData          = libphx.My_Struct_TakeBoxedData,
            GetData                = libphx.My_Struct_GetData,
            GetDataViaOutParam     = libphx.My_Struct_GetDataViaOutParam,
            GetDataRef             = libphx.My_Struct_GetDataRef,
            GetBoxedData           = libphx.My_Struct_GetBoxedData,
            GetDataMut             = libphx.My_Struct_GetDataMut,
            SetOpt                 = libphx.My_Struct_SetOpt,
            GetOptU32              = libphx.My_Struct_GetOptU32,
            GetOptData             = libphx.My_Struct_GetOptData,
            SetOptRef              = libphx.My_Struct_SetOptRef,
            SetOptMut              = libphx.My_Struct_SetOptMut,
            RetResVal              = libphx.My_Struct_RetResVal,
            RetResErr              = libphx.My_Struct_RetResErr,
            RetResOptVal           = libphx.My_Struct_RetResOptVal,
            SetCopyable            = libphx.My_Struct_SetCopyable,
            SetCopyableByRef       = libphx.My_Struct_SetCopyableByRef,
            SetCopyableByMutRef    = libphx.My_Struct_SetCopyableByMutRef,
            GetCopyable            = libphx.My_Struct_GetCopyable,
            GetCopyableViaOutParam = libphx.My_Struct_GetCopyableViaOutParam,
            GetBoxedCopyable       = libphx.My_Struct_GetBoxedCopyable,
        }

        if onDef_My_Struct then onDef_My_Struct(My_Struct, mt) end
        My_Struct = setmetatable(My_Struct, mt)
    end

    do -- Metatype for class instances
        local t  = ffi.typeof('My_Struct')
        local mt = {
            __index = {
                func1                  = libphx.My_Struct_Func1,
                func2                  = libphx.My_Struct_Func2,
                setU32                 = libphx.My_Struct_SetU32,
                getU32                 = libphx.My_Struct_GetU32,
                setF32                 = libphx.My_Struct_SetF32,
                getF32                 = libphx.My_Struct_GetF32,
                setStr                 = libphx.My_Struct_SetStr,
                getStr                 = libphx.My_Struct_GetStr,
                setData                = libphx.My_Struct_SetData,
                takeData               = libphx.My_Struct_TakeData,
                takeBoxedData          = libphx.My_Struct_TakeBoxedData,
                getData                = libphx.My_Struct_GetData,
                getDataViaOutParam     = libphx.My_Struct_GetDataViaOutParam,
                getDataRef             = libphx.My_Struct_GetDataRef,
                getBoxedData           = libphx.My_Struct_GetBoxedData,
                getDataMut             = libphx.My_Struct_GetDataMut,
                setOpt                 = libphx.My_Struct_SetOpt,
                getOptU32              = libphx.My_Struct_GetOptU32,
                getOptData             = libphx.My_Struct_GetOptData,
                setOptRef              = libphx.My_Struct_SetOptRef,
                setOptMut              = libphx.My_Struct_SetOptMut,
                setCopyable            = libphx.My_Struct_SetCopyable,
                setCopyableByRef       = libphx.My_Struct_SetCopyableByRef,
                setCopyableByMutRef    = libphx.My_Struct_SetCopyableByMutRef,
                getCopyable            = libphx.My_Struct_GetCopyable,
                getCopyableViaOutParam = libphx.My_Struct_GetCopyableViaOutParam,
                getBoxedCopyable       = libphx.My_Struct_GetBoxedCopyable,
            },
        }

        if onDef_My_Struct_t then onDef_My_Struct_t(t, mt) end
        My_Struct_t = ffi.metatype(t, mt)
    end

    return My_Struct
end

return Loader
```