### PR TITLE
Ignore stale colliders when looking at the narrowphase.

### DIFF
--- a/engine/lib/phx/src/physics/physics.rs
+++ b/engine/lib/phx/src/physics/physics.rs
@@ -266,12 +266,14 @@ impl Physics {
             iterator.index += 1;
 
             // Evaluate contact.
-            let c1_parent = RigidBody::linked_with_collider_mut(
-                world.colliders.get(contact_pair.collider1).unwrap(),
-            );
-            let c2_parent = RigidBody::linked_with_collider_mut(
-                world.colliders.get(contact_pair.collider2).unwrap(),
-            );
+            let c1_parent = world
+                .colliders
+                .get(contact_pair.collider1)
+                .and_then(RigidBody::linked_with_collider_mut);
+            let c2_parent = world
+                .colliders
+                .get(contact_pair.collider2)
+                .and_then(RigidBody::linked_with_collider_mut);
             if !c1_parent.is_some() || !c2_parent.is_some() {
                 continue;
             }

--- a/engine/lib/phx/src/physics/trigger.rs
+++ b/engine/lib/phx/src/physics/trigger.rs
@@ -154,19 +154,18 @@ impl Trigger {
         let world = &*world.as_ref();
 
         self.contents_cache.clear();
-        self.contents_cache
-            .extend(
-                world
-                    .narrow_phase
-                    .intersection_pairs_with(*collider)
-                    .filter_map(|pair| {
-                        let other_collider = if pair.0 == *collider { pair.1 } else { pair.0 };
-
-                        RigidBody::linked_with_collider_mut(
-                            world.colliders.get(other_collider).unwrap(),
-                        )
-                    }),
-            );
+        self.contents_cache.extend(
+            world
+                .narrow_phase
+                .intersection_pairs_with(*collider)
+                .filter_map(|pair| {
+                    let other_collider = if pair.0 == *collider { pair.1 } else { pair.0 };
+                    world
+                        .colliders
+                        .get(other_collider)
+                        .and_then(RigidBody::linked_with_collider_mut)
+                }),
+        );
 
         self.contents_cache.len() as i32
     }


### PR DESCRIPTION
This can happen if a collider is removed between when the narrowphase is updated (during a physics tick) and when we look at the narrowphase's results, either through Trigger.GetContentsCount, or Physics.GetNextCollision.