### PR TITLE
Initial version of the working tactical radar

### DIFF
--- a/docs/GameControlKeys.txt
+++ b/docs/GameControlKeys.txt
@@ -2,36 +2,37 @@ These are the controls for Limit Theory Redux.
 (Gamepad controls will be documented in an update.)
 
 *** MOVEMENT CONTROLS ***
-W, S   -- moves your ship forward and backward
-A, D   -- moves your ship left and right
-Ctrl   -- moves your ship down
-Space  -- moves your ship up
+W, S          -- moves your ship forward and backward
+A, D          -- moves your ship left and right
+Ctrl          -- moves your ship down
+Space         -- moves your ship up
 
 *** HUD, MAP, AND PANEL CONTROLS ***
-`      -- [backquote] enable flight mode overlay panels
--, =   -- in System Map, decrease/increase panning speed
-[, ]   -- in System Map, zoom in/out
-1 - 8  -- select a weapon group (can't change what's in a group yet, this is just group selection)
-Tab    -- toggle System Map on/off
-Return -- Activate the overlay panel for the currently focused panel icon
-G      -- disable target lock (HUD or System Map)
-N      -- target the nearest ship that is targeting the player's ship
-T      -- enable target lock on when the reticle is over a targetable object in Flight Mode view
-V      -- toggle the HUD off and back on again
-Z      -- toggle sensors display on/off
+`             -- [backquote] enable flight mode overlay panels
+-, =          -- in System Map, decrease/increase panning speed
+[, ]          -- in System Map, zoom in/out
+1 - 8         -- select a weapon group (can't change what's in a group yet, this is just group selection)
+Tab           -- toggle System Map on/off
+Return        -- Activate the overlay panel for the currently focused panel icon
+G             -- disable target lock (HUD or System Map)
+N             -- target the nearest ship that is targeting the player's ship
+T             -- enable target lock on when the reticle is over a targetable object in Flight Mode view
+V             -- toggle the HUD off and back on again
+Z             -- toggle sensors display on/off
+Numpad1, 2, 3 -- change range of tactical radar among Close, Normal, and Distant
 
 *** OTHER CONTROLS ***
-F1     -- switch to first-person camera
-F2     -- switch to chase camera
-F3     -- switch to orbiting camera (mostly useful when not actively flying)
-F10    -- toggle profiler on, then toggle off and display stats
-F11    -- toggle fullscreen on/off
-F12    -- take a screenshot (*.png) and save it to ./screenshot folder
-B      -- when in startup mode (not flight mode), generate a new background star system
-H      -- while held down, increase game processing speed
-K      -- toggle the realtime metrics overlay on/off
-L      -- toggle the dynamic lighting on/off (default is OFF, heavy performance cost!)
-M      -- toggle autopilot: click on target (world view or System Map), then press this key to fly there
-P      -- pause and unpause the game (flight mode)
-Ctrl-W -- immediately exit game
-Alt-Q  -- immediately exit game
+F1            -- switch to first-person camera
+F2            -- switch to chase camera
+F3            -- switch to orbiting camera (mostly useful when not actively flying)
+F10           -- toggle profiler on, then toggle off and display stats
+F11           -- toggle fullscreen on/off
+F12           -- take a screenshot (*.png) and save it to ./screenshot folder
+B             -- when in startup mode (not flight mode), generate a new background star system
+H             -- while held down, increase game processing speed
+K             -- toggle the realtime metrics overlay on/off
+L             -- toggle the dynamic lighting on/off (default is OFF, heavy performance cost!)
+M             -- toggle autopilot: click on target (world view or System Map), then press this key to fly there
+P             -- pause and unpause the game (flight mode)
+Ctrl-W        -- immediately exit game
+Alt-Q         -- immediately exit game

--- a/script/Config/UI/UIConfig.lua
+++ b/script/Config/UI/UIConfig.lua
@@ -10,6 +10,8 @@ Config.ui.general = {
     cursorX                          = 1,
     cursorY                          = 1,
 
+    rangeDistances = {3000.0, 6000.0, 10000.0}, -- maximum distances within which objects appear on tactical map
+
     -- Trackers
     showTrackers                     = true,
     maxTrackingRange                 = 500000,

--- a/script/Enums/HudEnums.lua
+++ b/script/Enums/HudEnums.lua
@@ -1,6 +1,7 @@
 -- Enumerations for HUD modes
 Enums.HudStyleCount = 5
 
+---@enum HudStyles
 Enums.HudStyles = {
     None     = 1,
     Minimal  = 2,
@@ -9,6 +10,7 @@ Enums.HudStyles = {
     Tight    = 5,
 }
 
+---@enum HudStyleNames
 Enums.HudStyleNames = {
     "None",
     "Minimal",
@@ -17,6 +19,7 @@ Enums.HudStyleNames = {
     "Tight",
 }
 
+---@enum HudTacMapRanges
 Enums.HudTacMapRanges = {
     Close   = 1,
     Normal  = 2,

--- a/script/Enums/HudEnums.lua
+++ b/script/Enums/HudEnums.lua
@@ -16,3 +16,9 @@ Enums.HudStyleNames = {
     "Balanced",
     "Tight",
 }
+
+Enums.HudTacMapRanges = {
+    Close   = 1,
+    Normal  = 2,
+    Distant = 3,
+}

--- a/script/Systems/Overlay/HUD.lua
+++ b/script/Systems/Overlay/HUD.lua
@@ -1112,6 +1112,7 @@ function HUD:drawTacticalMap(a)
     local cx, cy = self.sx / 2, self.sy / 2
     local radiusOuterRing = 70
     local radiusInnerRing = 44
+    local radiusScaleRing = 10
 
     -- Draw tactical map
     UI.DrawEx.Ring(cx, self.sy - 76, radiusOuterRing, Config.ui.color.meterBarLight, true)
@@ -1123,8 +1124,13 @@ function HUD:drawTacticalMap(a)
     UI.DrawEx.Line(cx - 48, self.sy - 124, cx, self.sy - 78, Config.ui.color.meterBarLight, false)
     UI.DrawEx.Line(cx + 48, self.sy - 124, cx, self.sy - 78, Config.ui.color.meterBarLight, false)
 
+    UI.DrawEx.Ring(cx - 70, self.sy - 16, radiusScaleRing, Config.ui.color.meterBarLight, false)
+    UI.DrawEx.Ring(cx + 70, self.sy - 16, radiusScaleRing, Config.ui.color.meterBarLight, false)
+
+    UI.DrawEx.TextAlpha("UbuntuBold", "-", 34, cx - 75, self.sy - 14, 10, 10, 0.5, 0.6, 1.0, 1.0, 0.5, 0.5)
+    UI.DrawEx.TextAlpha("UbuntuBold", "+", 28, cx + 65, self.sy - 21, 10, 10, 0.5, 0.6, 1.0, 1.0, 0.5, 0.5)
+
     -- Loop through nearby stations and ships and draw them on the tactical map
-    local maxDist = 6000.0 -- maximum distance within which objects appear on tactical map
     local ix = self.sx / 2
     local iy = self.sy - 76
     local r = 1.0
@@ -1137,6 +1143,7 @@ function HUD:drawTacticalMap(a)
     if system and not playerShip:isShipDocked() then -- no need to update tactical map while docked at a space station
         local stations = system:getStations()
         local ships    = system:getShips()
+        local maxDist  = Config.ui.general.rangeDistances[GameState.ui.tacMapRange]
 
         for _, station in ipairs(stations) do
             local dist = playerShip:getDistance(station)
@@ -1168,8 +1175,6 @@ function HUD:drawTacticalMap(a)
                 -- local c = target:getDispositionColor(disp) -- this version is preserved for future changes (esp. faction)
                 local c = Disposition.GetColor(disp)
 
---                r = 0.01
---                UI.DrawEx.Circle(x, y, r, c)
                 UI.DrawEx.Point(x, y, 256, c)
             end
         end
@@ -1751,7 +1756,7 @@ function HUD:onInput(state)
         -- camera:modYaw(0.005 * CameraBindings.Yaw:get())     -- only works when cameraOrbit is the current camera
         -- camera:modPitch(0.005 * CameraBindings.Pitch:get()) -- only works when cameraOrbit is the current camera
 
-        -- Select a weapon group
+        -- HUD control: Select a weapon group
         if InputInstance:isPressed(Button.KeyboardKey1) and GameState.player.weaponGroup ~= 1 then
             GameState.player.weaponGroup = 1
         elseif InputInstance:isPressed(Button.KeyboardKey2) and GameState.player.weaponGroup ~= 2 then
@@ -1770,6 +1775,16 @@ function HUD:onInput(state)
             GameState.player.weaponGroup = 8
         end
 
+        -- HUD control: Select a tactical map range (close, normal, distant)
+        if InputInstance:isPressed(Button.KeyboardNumpad1) then
+            GameState.ui.tacMapRange = 1
+        elseif InputInstance:isPressed(Button.KeyboardNumpad2) then
+            GameState.ui.tacMapRange = 2
+        elseif InputInstance:isPressed(Button.KeyboardNumpad3) then
+            GameState.ui.tacMapRange = 3
+        end
+
+        -- Process player ship control actions
         local e = self.player:getControlling()
         if not e:isDestroyed() then
             self:controlThrust(e)
@@ -1942,7 +1957,7 @@ function HUD:onDrawIcon(iconButton, focus, active)
 end
 
 function HUD:onEnable()
-    -- TODO : Wtf does this do? Who wrote this?? WHY.
+    -- TODO : Wtf does this do? Who wrote this?? WHY. [<-- this comment was from Josh or Adam]
     local pCamera = self.gameView.camera
     local camera = self.gameView.camera
 

--- a/script/Systems/Overlay/HUD.lua
+++ b/script/Systems/Overlay/HUD.lua
@@ -24,6 +24,10 @@ local updateSensorsInterval = 2 / 10
 local deltaSensorsTimer = 0
 local barTweak = 0
 
+local updateTargetsInterval = 1 / 60
+local lastTargetsUpdate = 0
+local deltaTimer = 0
+
 function HUD:drawSystemText(a)
     local cx, cy = self.sx / 2, self.sy / 2
 
@@ -393,7 +397,7 @@ function HUD:drawTargetSpeed(a)
         local hudFsize = hudFontSize
         if GameState.ui.hudStyle == Enums.HudStyles.Wide then
             hudX = cx + 70
-            hudY = 150
+            hudY = 146
             hudFsize = hudFontSize
         elseif GameState.ui.hudStyle == Enums.HudStyles.Balanced then
             hudX = cx + 70
@@ -1113,26 +1117,27 @@ function HUD:drawTacticalMap(a)
     local radiusOuterRing = 70
     local radiusInnerRing = 44
     local radiusScaleRing = 10
+    local mapHeight = 82
 
     -- Draw tactical map
-    UI.DrawEx.Ring(cx, self.sy - 76, radiusOuterRing, Config.ui.color.meterBarLight, true)
-    UI.DrawEx.Ring(cx, self.sy - 76, radiusInnerRing, Config.ui.color.meterBarLight, false)
+    if GameState.ui.tacMapRange > Enums.HudTacMapRanges.Normal then
+        UI.DrawEx.Ring(cx, self.sy - mapHeight, radiusOuterRing + 10, Config.ui.color.meterBarLight, true)
+    end
+    if GameState.ui.tacMapRange > Enums.HudTacMapRanges.Close then
+        UI.DrawEx.Ring(cx, self.sy - mapHeight, radiusOuterRing + 5, Config.ui.color.meterBarLight, true)
+    end
+    UI.DrawEx.Ring(cx, self.sy - mapHeight, radiusOuterRing, Config.ui.color.meterBarLight, true)
+    UI.DrawEx.Ring(cx, self.sy - mapHeight, radiusInnerRing, Config.ui.color.meterBarLight, false)
 
-    UI.DrawEx.Line(cx, self.sy - 144, cx, self.sy - 6, Config.ui.color.meterBarLight, false)
-    UI.DrawEx.Line(cx - radiusOuterRing, self.sy - 78, cx + radiusOuterRing, self.sy - 78, Config.ui.color.meterBarLight, false)
+    UI.DrawEx.Line(cx, self.sy - 150, cx, self.sy - 12, Config.ui.color.meterBarLight, false)
+    UI.DrawEx.Line(cx - radiusOuterRing, self.sy - 84, cx + radiusOuterRing, self.sy - 84, Config.ui.color.meterBarLight, false)
 
-    UI.DrawEx.Line(cx - 48, self.sy - 124, cx, self.sy - 78, Config.ui.color.meterBarLight, false)
-    UI.DrawEx.Line(cx + 48, self.sy - 124, cx, self.sy - 78, Config.ui.color.meterBarLight, false)
-
-    UI.DrawEx.Ring(cx - 70, self.sy - 16, radiusScaleRing, Config.ui.color.meterBarLight, false)
-    UI.DrawEx.Ring(cx + 70, self.sy - 16, radiusScaleRing, Config.ui.color.meterBarLight, false)
-
-    UI.DrawEx.TextAlpha("UbuntuBold", "-", 34, cx - 75, self.sy - 14, 10, 10, 0.5, 0.6, 1.0, 1.0, 0.5, 0.5)
-    UI.DrawEx.TextAlpha("UbuntuBold", "+", 28, cx + 65, self.sy - 21, 10, 10, 0.5, 0.6, 1.0, 1.0, 0.5, 0.5)
+    UI.DrawEx.Line(cx - 48, self.sy - 130, cx, self.sy - 84, Config.ui.color.meterBarLight, false)
+    UI.DrawEx.Line(cx + 48, self.sy - 130, cx, self.sy - 84, Config.ui.color.meterBarLight, false)
 
     -- Loop through nearby stations and ships and draw them on the tactical map
     local ix = self.sx / 2
-    local iy = self.sy - 76
+    local iy = self.sy - mapHeight
     local r = 1.0
     local c = Color(1.0, 1.0, 1.0, 1.0)
 
@@ -1180,10 +1185,6 @@ function HUD:drawTacticalMap(a)
         end
     end
 end
-
-local updateTargetsInterval = 1 / 60
-local lastTargetsUpdate = 0
-local deltaTimer = 0
 
 local function getPosObject(def)
     local object = {}

--- a/script/Systems/Universe/UniverseEconomy.lua
+++ b/script/Systems/Universe/UniverseEconomy.lua
@@ -116,7 +116,7 @@ local function addMarket(system)
             -- Create Stations within randomly selected AsteroidField Zones
             system:spawnStation(Enums.StationHulls.Small, aiPlayer)
         end
-        print("Spawned %d Stations for AI Player %s", GameState.gen.nStations, aiPlayer:getName())
+        printf("Spawned %d stations for AI Player '%s'", GameState.gen.nStations, aiPlayer:getName())
         -- Add AI Player to the system
         table.insert(system.aiPlayers, aiPlayer)
     end

--- a/script/Types/GameState.lua
+++ b/script/Types/GameState.lua
@@ -73,6 +73,8 @@ GameState.ui = {
     },
     trackerObjectOcclusion           = Config.ui.general.trackerObjectOcclusion,
 
+    tacMapRange                      = Enums.HudTacMapRanges.Normal,
+
     mapSystemPanSpeed                = 0.5,
     mapSystemZoomSpeed               = 0.1,
 

--- a/script/UI/DrawEx.lua
+++ b/script/UI/DrawEx.lua
@@ -211,9 +211,22 @@ end
 
 function DrawEx.Point(x, y, r, color)
     local x, y, sx, sy = padAndCenter(padPoint, x, y, r, r)
-    BlendMode.PushAdditive()
     local shader = Cache.Shader('ui', 'ui/point') -- previously used 'ui/circle-old' shader
     local alpha = alphaStack:last() or 1
+    BlendMode.PushAlpha()
+    shader:start()
+    Shader.SetFloat2('size', sx, sy)
+    Shader.SetFloat4('color', color.r, color.g, color.b, color.a * alpha)
+    Draw.Rect(x, y, sx, sy)
+    shader:stop()
+    BlendMode.Pop()
+end
+
+function DrawEx.PointGlow(x, y, r, color)
+    local x, y, sx, sy = padAndCenter(padPoint, x, y, r, r)
+    local shader = Cache.Shader('ui', 'ui/point') -- previously used 'ui/circle-old' shader
+    local alpha = alphaStack:last() or 1
+    BlendMode.PushAdditive()
     shader:start()
     Shader.SetFloat2('size', sx, sy)
     Shader.SetFloat4('color', color.r, color.g, color.b, color.a * alpha)


### PR DESCRIPTION
First draft of a tactical radar that displays nearby vessels (ships and stations).

For quick clarity, the initial version uses only the x (0 to infinity to 0 to -infinity to 0) and y (1 or -1) components of `self.gameView.camera:worldToNDC(object:getPos())` to position vessels on the radar. The y component ("up" or "down" relative to the player ship's facing) is not currently used. (This actually works pretty well -- try it!)

The Numpad1, Numpad2, and Numpad3 keys change the current range of the tactical radar among Close, Normal, and Distant.

Ship dots are small; station dots are large.

The color of radar dots are drawn according to the color returned by a Disposition check.

Bugs:
* Although the values returned from `worldToNDC()` can go as high as +/- infinity, they are cut off at 1.57 which corresponds to pi/2 (90 degrees), otherwise the sin() and cos() of the value fluctuates wildly as the value approaches +/- infinity. This cutoff results in ships near 90 and 270 degrees seeming to be briefly "stuck" to the right or left side of the tactical radar. Some alternate math is needed to smooth out this transition at 90 and 270 degrees.

Possible future enhancements:
* If the player has a target lock on a vessel, draw a box around that vessel in the radar
* Include y-axis information (_IFF_ that adds more practical utility than complexity)