### PR TITLE
Generate meta files as CRLF on Windows.

### DIFF
--- a/engine/lib/luajit-ffi-gen/src/ffi_generator.rs
+++ b/engine/lib/luajit-ffi-gen/src/ffi_generator.rs
@@ -375,6 +375,10 @@ impl FfiGenerator {
             self.class_definitions
                 .iter()
                 .for_each(|def| writeln!(&mut meta_def, "{def}").unwrap());
+            
+            if cfg!(windows) {
+                meta_def = meta_def.replace("\n", "\r\n");
+            }
 
             meta_def_file.write_all(meta_def.as_bytes()).unwrap();
         }


### PR DESCRIPTION
When git checks out these files, they are checked out as CRLF. Then, when luajit-ffi-gen runs, they get replaced with LF and so git thinks the files have changed.