### PR TITLE
Update github actions runner to macos-12

### DIFF
--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -88,7 +88,7 @@ jobs:
   build-macos:
     needs: gen-build-version
     name: Build macOS
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -89,7 +89,7 @@ jobs:
   build-macos:
     needs: gen-build-version
     name: Build macOS
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
the macos-11 image was deprecated in January, and is apparently going through a brownout in late June: https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/#macos-11-deprecation-and-removal