### PR TITLE
Fix crash when triggering screenshot

### DIFF
--- a/engine/lib/luajit-ffi-gen/src/ffi_generator.rs
+++ b/engine/lib/luajit-ffi-gen/src/ffi_generator.rs
@@ -375,7 +375,7 @@ impl FfiGenerator {
             self.class_definitions
                 .iter()
                 .for_each(|def| writeln!(&mut meta_def, "{def}").unwrap());
-            
+
             if cfg!(windows) {
                 meta_def = meta_def.replace("\n", "\r\n");
             }

--- a/engine/lib/luajit-ffi-gen/src/impl_item/generate.rs
+++ b/engine/lib/luajit-ffi-gen/src/impl_item/generate.rs
@@ -21,10 +21,7 @@ impl ImplInfo {
             .map(|method| self.wrap_method(&module_name, method))
             .collect();
 
-        let is_managed = self
-            .methods
-            .iter()
-            .any(|method| method.bind_args.gen_lua_ffi() && method.self_param.is_some());
+        let is_managed = self.is_managed();
 
         // Additional Free C API wrapper if managed
         let free_method_token = if is_managed {

--- a/engine/lib/luajit-ffi-gen/src/impl_item/impl_info.rs
+++ b/engine/lib/luajit-ffi-gen/src/impl_item/impl_info.rs
@@ -11,3 +11,16 @@ pub struct ImplInfo {
     /// `impl` methods information
     pub methods: Vec<MethodInfo>,
 }
+
+impl ImplInfo {
+    // This type is managed if if has any methods which either have a `self` parameter, or any methods return an instance of this.
+    pub fn is_managed(&self) -> bool {
+        self.methods.iter().any(|method| {
+            if method.bind_args.gen_lua_ffi() {
+                method.self_param.is_some() || method.ret.as_ref().is_some_and(|ret| ret.is_self())
+            } else {
+                false
+            }
+        })
+    }
+}

--- a/engine/lib/luajit-ffi-gen/src/impl_item/lua_ffi.rs
+++ b/engine/lib/luajit-ffi-gen/src/impl_item/lua_ffi.rs
@@ -7,10 +7,7 @@ impl ImplInfo {
     pub fn generate_ffi(&self, attr_args: &ImplAttrArgs) {
         let module_name = attr_args.name().unwrap_or(self.name.clone());
         let mut ffi_gen = FfiGenerator::load(&module_name);
-        let is_managed = self
-            .methods
-            .iter()
-            .any(|method| method.bind_args.gen_lua_ffi() && method.self_param.is_some());
+        let is_managed = self.is_managed();
 
         // Generate metatype section only if there is at least one method with `self` parameter,
         // or clone parameter is set

--- a/engine/lib/phx/script/ffi_gen/Time.lua
+++ b/engine/lib/phx/script/ffi_gen/Time.lua
@@ -12,6 +12,7 @@ function Loader.defineType()
 
     do -- C Definitions
         ffi.cdef [[
+            void   Time_Free     (Time*);
             Time*  Time_GetLocal ();
             Time*  Time_GetUtc   ();
             uint32 Time_GetRaw   ();

--- a/engine/lib/phx/src/audio/audio.rs
+++ b/engine/lib/phx/src/audio/audio.rs
@@ -164,7 +164,7 @@ impl Audio {
     pub fn listener_rot(&self) -> Quat {
         self.listener_info.orientation
     }
-    
+
     /// Updates the origin in Kira's coordinate system.
     ///
     /// As Kira maintains a 32-bit coordinate system, if the listener strays too far away from the origin, we will start to have difficulty with 32-bit precision.

--- a/engine/lib/phx/src/physics/physics.rs
+++ b/engine/lib/phx/src/physics/physics.rs
@@ -420,7 +420,7 @@ impl Physics {
     pub fn draw_wireframes(&mut self, eye: &Position) {
         let world = self.world.as_ref();
         self.debug_renderer.render(
-            &mut RapierDebugRenderer{eye: *eye},
+            &mut RapierDebugRenderer { eye: *eye },
             &world.rigid_bodies,
             &world.colliders,
             &self.impulse_joints,

--- a/engine/lib/phx/src/render/bsp.rs
+++ b/engine/lib/phx/src/render/bsp.rs
@@ -1386,19 +1386,23 @@ pub unsafe extern "C" fn BSPDebug_DrawNodeSplit(this: &mut BSP, nodeRef: BSPNode
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn BSPDebug_DrawLineSegment(bsp: &mut BSP, lineSegment: &mut LineSegment, eye: &Position) {
+pub unsafe extern "C" fn BSPDebug_DrawLineSegment(
+    bsp: &mut BSP,
+    lineSegment: &mut LineSegment,
+    eye: &Position,
+) {
     let mut pHit = Vec3::ZERO;
     if BSP_IntersectLineSegment(bsp, lineSegment, &mut pHit) {
         Draw_Color(0.0f32, 1.0f32, 0.0f32, 0.1f32);
         Draw_Line3(
             &(*lineSegment).p0.relative_to(*eye),
-            &Position::from_vec(pHit).relative_to(*eye)
+            &Position::from_vec(pHit).relative_to(*eye),
         );
 
         Draw_Color(1.0f32, 0.0f32, 0.0f32, 1.0f32);
         Draw_Line3(
             &Position::from_vec(pHit).relative_to(*eye),
-            &(*lineSegment).p1.relative_to(*eye)
+            &(*lineSegment).p1.relative_to(*eye),
         );
 
         Draw_PointSize(5.0f32);
@@ -1407,7 +1411,7 @@ pub unsafe extern "C" fn BSPDebug_DrawLineSegment(bsp: &mut BSP, lineSegment: &m
         Draw_Color(0.0f32, 1.0f32, 0.0f32, 1.0f32);
         Draw_Line3(
             &(*lineSegment).p0.relative_to(*eye),
-            &(*lineSegment).p1.relative_to(*eye)
+            &(*lineSegment).p1.relative_to(*eye),
         );
     };
 }


### PR DESCRIPTION
This was happening because the Time_Free method wasn't being generated correctly. We try to detect when a type needs a _Free method by checking to see if we have any methods that take `self` as the first argument. `Time` is quite unique in that it has no methods that take `self` as the first argument, but it does have methods that return `Time`. This was causing the _Free method to not be generated, which was causing a crash when the `Time` object was being freed.

At the same time, I decided to run `cargo fmt`.

Now, when you press F12, it correctly generates a screenshot.

/cc @Flatfingers
