### PR TITLE
Set up a custom panic hook which invokes the crash handler in Lua.

### DIFF
--- a/engine/lib/phx/src/engine/engine.rs
+++ b/engine/lib/phx/src/engine/engine.rs
@@ -1,5 +1,6 @@
 use glam::*;
 use mlua::{Function, Lua};
+use std::cell::RefCell;
 use std::path::PathBuf;
 use tracing::*;
 use winit::dpi::*;
@@ -11,6 +12,7 @@ use crate::common::*;
 use crate::input::*;
 use crate::logging::init_log;
 use crate::render::*;
+use crate::rf::*;
 use crate::system::*;
 use crate::ui::hmgui::HmGui;
 use crate::window::*;
@@ -25,7 +27,13 @@ pub struct Engine {
     pub hmgui: HmGui,
     pub input: Input,
     pub exit_app: bool,
-    pub lua: Lua,
+    pub lua: Rf<Lua>,
+}
+
+// This thread local variable contains a ref counted instance of the current Lua VM.
+// This is used by the panic hook to tell the Lua VM to generate backtrace.
+thread_local! {
+    static CURRENT_LUA_CTX: RefCell<Option<Rf<Lua>>> = RefCell::new(None);
 }
 
 impl Engine {
@@ -43,7 +51,43 @@ impl Engine {
         }
 
         // Unsafe is required for FFI and JIT libs
-        let lua = unsafe { Lua::unsafe_new() };
+        let lua = Rf::new(unsafe { Lua::unsafe_new() });
+
+        std::panic::set_hook(Box::new(|panic_info| {
+            error!(
+                "panic occurred in engine code! backtrace:\n{}",
+                std::backtrace::Backtrace::force_capture()
+            );
+
+            let location = if let Some(location) = panic_info.location() {
+                format!("{}:{}", location.file(), location.line(),)
+            } else {
+                "<unknown>".to_string()
+            };
+
+            let panic_message = if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
+                format!("panic occurred at {location} - {s:?}")
+            } else {
+                format!("panic occurred at {location}")
+            };
+
+            CURRENT_LUA_CTX.with_borrow(|v| {
+                if let Some(ctx) = v {
+                    let lua = ctx.as_ref();
+                    let handle_error_func: Function = lua
+                        .globals()
+                        .get("HandleEngineError")
+                        .expect("Unknown function HandleEngineError");
+                    if let Err(e) = handle_error_func.call::<_, ()>(panic_message) {
+                        trace!("{}", e);
+                    }
+                } else {
+                    error!("No Lua VM context, cannot get Lua backtrace.")
+                }
+            });
+
+            std::process::exit(1);
+        }));
 
         // Create window.
         let window = Window::default();
@@ -66,14 +110,19 @@ impl Engine {
         }
     }
 
-    pub fn call_lua_func(&self, func_name: &str) {
-        let globals = self.lua.globals();
-        let app_frame_func: Function = globals
+    pub fn call_lua(&self, func_name: &str) -> Result<(), mlua::Error> {
+        CURRENT_LUA_CTX.with_borrow_mut(|v| *v = Some(self.lua.clone()));
+
+        let lua = self.lua.as_ref();
+        let lua_func: Function = lua
+            .globals()
             .get(func_name)
             .expect(format!("Unknown function {}", func_name).as_str());
-        if let Err(e) = app_frame_func.call::<_, ()>(()) {
-            trace!("{}", e);
-        }
+        let result = lua_func.call::<_, ()>(());
+
+        CURRENT_LUA_CTX.with_borrow_mut(|v| *v = None);
+
+        result
     }
 
     // Apply user changes, and then detect changes to the window and update the winit window accordingly.

--- a/engine/lib/phx/src/engine/main_loop.rs
+++ b/engine/lib/phx/src/engine/main_loop.rs
@@ -24,38 +24,38 @@ impl ApplicationHandler for MainLoop {
             self.engine = Some(Engine::new(event_loop));
             let engine = self.engine.as_mut().unwrap();
 
-            let globals = engine.lua.globals();
+            // Set engine pointer.
+            {
+                let lua = engine.lua.as_ref();
+                let globals = lua.globals();
 
-            globals.set("__debug__", cfg!(debug_assertions)).unwrap();
-            globals.set("__embedded__", true).unwrap();
-            globals.set("__checklevel__", 0 as u64).unwrap();
+                globals.set("__debug__", cfg!(debug_assertions)).unwrap();
+                globals.set("__embedded__", true).unwrap();
+                globals.set("__checklevel__", 0 as u64).unwrap();
 
-            if !self.app_name.is_empty() {
-                globals.set("__app__", self.app_name.clone()).unwrap();
+                if !self.app_name.is_empty() {
+                    globals.set("__app__", self.app_name.clone()).unwrap();
+                }
+
+                lua.load(&*self.entry_point_path)
+                    .exec()
+                    .unwrap_or_else(|e| {
+                        panic!("Error executing the entry point script: {}", e);
+                    });
+
+                let set_engine_func: Function = globals.get("SetEngine").unwrap();
+                set_engine_func
+                    .call::<_, ()>(engine as *const Engine as usize)
+                    .unwrap_or_else(|e| {
+                        panic!("Error calling SetEngine: {}", e);
+                    });
             }
 
-            engine
-                .lua
-                .load(&*self.entry_point_path)
-                .exec()
-                .unwrap_or_else(|e| {
-                    panic!("Error executing the entry point script: {}", e);
-                });
-
-            let set_engine_func: Function = globals.get("SetEngine").unwrap();
-            set_engine_func
-                .call::<_, ()>(engine as *const Engine as usize)
-                .unwrap_or_else(|e| {
-                    panic!("Error calling SetEngine: {}", e);
-                });
-
-            let init_system_func: Function = globals.get("InitSystem").unwrap();
-            init_system_func.call::<_, ()>(()).unwrap_or_else(|e| {
+            engine.call_lua("InitSystem").unwrap_or_else(|e| {
                 panic!("Error calling InitSystem: {}", e);
             });
 
-            let app_init_func: Function = globals.get("AppInit").unwrap();
-            app_init_func.call::<_, ()>(()).unwrap_or_else(|e| {
+            engine.call_lua("AppInit").unwrap_or_else(|e| {
                 panic!("Error calling AppInit: {}", e);
             });
         }
@@ -255,7 +255,9 @@ impl ApplicationHandler for MainLoop {
         engine.input.update_gamepad(|state| state.update());
 
         // Let Lua script perform frame operations
-        engine.call_lua_func("AppFrame");
+        engine.call_lua("AppFrame").unwrap_or_else(|e| {
+            panic!("Error calling AppInit: {}", e);
+        });
 
         // Apply window changes made by a script
         engine.changed_window();
@@ -271,7 +273,9 @@ impl ApplicationHandler for MainLoop {
         };
 
         debug!("Stopping main loop!");
-        engine.call_lua_func("AppClose");
+        engine.call_lua("AppClose").unwrap_or_else(|e| {
+            panic!("Error calling AppInit: {}", e);
+        });
     }
 
     fn memory_warning(&mut self, _: &ActiveEventLoop) {}

--- a/engine/lib/phx/src/logging.rs
+++ b/engine/lib/phx/src/logging.rs
@@ -59,7 +59,8 @@ pub fn init_log(console_log: bool, log_dir: &str) -> Option<WorkerGuard> {
 
         if console_log {
             let console_output_layer = tracing_subscriber::fmt::layer()
-                .with_ansi(true)
+                .without_time()
+                .with_level(false)
                 .with_target(false);
 
             registry
@@ -78,7 +79,8 @@ pub fn init_log(console_log: bool, log_dir: &str) -> Option<WorkerGuard> {
     } else {
         if console_log {
             let console_output_layer = tracing_subscriber::fmt::layer()
-                .with_ansi(true)
+                .without_time()
+                .with_level(false)
                 .with_target(false);
 
             registry

--- a/script/Main.lua
+++ b/script/Main.lua
@@ -13,6 +13,7 @@ WindowInstance = {}
 Gui = {}
 
 require('Init')
+local ErrorHandler = require('Core.Util.ErrorHandler')
 
 function SetEngine(engine)
     Log.Debug("SetEngine")
@@ -122,4 +123,8 @@ function InitSystem()
             GlobalRestrict.Off()
         end
     end)
+end
+
+function HandleEngineError(err)
+    ErrorHandler(err)
 end


### PR DESCRIPTION
This means whenever the Rust code triggers a `panic!(...)`, the user will get both a Rust and Lua backtrace.

![Screenshot 2024-07-16 at 00 40 14](https://github.com/user-attachments/assets/c5bf2304-6a9d-4ee4-8aa4-d28f9653fdc0)

This works by storing the currently running Lua VM in a ref counted pointer, then making that available in a thread local variable. When a panic occurs, we use that thread local variable to trigger the `HandleEngineError` global function in the Lua VM.