### PR TITLE
Add support for Lua LSP declarations

### DIFF
--- a/engine/lib/luajit-ffi-gen/src/impl_item/lua_ffi.rs
+++ b/engine/lib/luajit-ffi-gen/src/impl_item/lua_ffi.rs
@@ -71,6 +71,7 @@ impl ImplInfo {
                 method
                     .doc
                     .iter()
+                    .filter(|d| d.is_empty() || &d[0..1] != "@")
                     .for_each(|d| ffi_gen.add_class_definition(format!("-- {d}")));
 
                 // Add method signature documentation
@@ -103,6 +104,13 @@ impl ImplInfo {
                         ));
                     }
                 }
+
+                // Add user defined Lua LSP directives
+                method
+                    .doc
+                    .iter()
+                    .filter(|d| !d.is_empty() && &d[0..1] == "@")
+                    .for_each(|d| ffi_gen.add_class_definition(format!("---{d}")));
 
                 if method.self_param.is_some() {
                     ffi_gen.add_class_definition(format!(

--- a/engine/lib/phx/src/ui/hmgui/mod.rs
+++ b/engine/lib/phx/src/ui/hmgui/mod.rs
@@ -59,7 +59,7 @@ mod tests {
             }
         }
 
-        (HmGui::new(), Default::default())
+        (HmGui::new(1.0), Default::default())
     }
 
     fn check_widget(widget: &Ref<'_, HmGuiWidget>, expected: &WidgetCheck) {


### PR DESCRIPTION
Example:

Rust
```rust
/// @overload fun(self: table, eventName: string, ctxTable: table, callbackFunc: function): integer
```
Generated meta:
```lua
---@overload fun(self: table, eventName: string, ctxTable: table, callbackFunc: function): integer
```