### PR TITLE
Add EventTest

### DIFF
--- a/script/States/App/Tests/EventTest.lua
+++ b/script/States/App/Tests/EventTest.lua
@@ -1,0 +1,45 @@
+local EventTest = require('States.Application')
+
+local iteration = 0
+
+function EventTest:onInit()
+    local fakeEntity = { getGuid = function() return 0 end }
+
+    EventBusInstance:subscribe(FrameStage.ToString(FrameStage.PreSim), fakeEntity, function() Log.Debug("onPreSim") end)
+    EventBusInstance:subscribe(FrameStage.ToString(FrameStage.Sim), fakeEntity,  function() Log.Debug("onSim") end)
+    EventBusInstance:subscribe(FrameStage.ToString(FrameStage.PostSim), fakeEntity,  function() Log.Debug("onPostSim") end)
+    EventBusInstance:subscribe(FrameStage.ToString(FrameStage.PreRender), fakeEntity,  function() Log.Debug("onPreRender") end)
+    EventBusInstance:subscribe(FrameStage.ToString(FrameStage.Render), fakeEntity,  function() Log.Debug("onRender") end)
+    EventBusInstance:subscribe(FrameStage.ToString(FrameStage.PostRender), fakeEntity,  function() Log.Debug("onPostRender") end)
+    EventBusInstance:subscribe(FrameStage.ToString(FrameStage.PreInput), fakeEntity,  function() Log.Debug("onPreInput") end)
+    EventBusInstance:subscribe(FrameStage.ToString(FrameStage.Input), fakeEntity,  function() Log.Debug("onInput") end)
+    EventBusInstance:subscribe(FrameStage.ToString(FrameStage.PostInput), fakeEntity,  function() Log.Debug("onPostInput") end)
+
+    EventBusInstance:subscribe(FrameStage.ToString(FrameStage.PreSim), fakeEntity, function() Log.Debug("onPreSim2") end)
+    EventBusInstance:subscribe(FrameStage.ToString(FrameStage.Sim), fakeEntity,  function() Log.Debug("onSim2") end)
+    EventBusInstance:subscribe(FrameStage.ToString(FrameStage.PostSim), fakeEntity,  function() Log.Debug("onPostSim2") end)
+    EventBusInstance:subscribe(FrameStage.ToString(FrameStage.PreRender), fakeEntity,  function() Log.Debug("onPreRender2") end)
+    EventBusInstance:subscribe(FrameStage.ToString(FrameStage.Render), fakeEntity,  function() Log.Debug("onRender2") end)
+    EventBusInstance:subscribe(FrameStage.ToString(FrameStage.PostRender), fakeEntity,  function() Log.Debug("onPostRender2") end)
+    EventBusInstance:subscribe(FrameStage.ToString(FrameStage.PreInput), fakeEntity,  function() Log.Debug("onPreInput2") end)
+    EventBusInstance:subscribe(FrameStage.ToString(FrameStage.Input), fakeEntity,  function() Log.Debug("onInput2") end)
+    EventBusInstance:subscribe(FrameStage.ToString(FrameStage.PostInput), fakeEntity,  function()
+        Log.Debug("onPostInput2")
+        Log.Debug("========")
+        iteration = iteration + 1
+        if iteration == 3 then
+            os.exit()
+        end
+    end)
+end
+
+function EventTest:onPreRender()
+end
+
+function EventTest:onRender()
+end
+
+function EventTest:onPostRender()
+end
+
+return EventTest

--- a/script/States/Application.lua
+++ b/script/States/Application.lua
@@ -138,7 +138,7 @@ function Application:onPreRender()
     local timeScaledDt = self.timeScale * self.dt
 
     --* system & canvas should probably subscribe to onPreRender themselves
-    if GameState.player.humanPlayer:getRoot().update then
+    if GameState.player.humanPlayer and GameState.player.humanPlayer:getRoot().update then
         GameState.player.humanPlayer:getRoot():update(timeScaledDt)
         GameState.render.uiCanvas:update(timeScaledDt)
     end
@@ -167,8 +167,10 @@ function Application:onRender()
     WindowInstance:beginDraw()
 
     --* should they subscribe to onRender themselves?
-    GameState.render.uiCanvas:draw(self.resX, self.resY)
-    Gui:draw()
+    if GameState.render.uiCanvas ~= nil then
+        GameState.render.uiCanvas:draw(self.resX, self.resY)
+        Gui:draw()
+    end
 
     Profiler.End()
 
@@ -326,7 +328,9 @@ function Application:onInput()
     end
 
     --! why is this needed for the game to render and update lol
-    GameState.render.uiCanvas:input()
+    if GameState.render.uiCanvas ~= nil then
+        GameState.render.uiCanvas:input()
+    end
 
     Profiler.End()
 end


### PR DESCRIPTION
This demonstrates a bug where an event is not delivered in some cases. Looks like `preRender` is not called in the first iteration:

```
 WARN Context is already current
DEBUG [lua] onPreSim
DEBUG [lua] onPreSim2
DEBUG [lua] onSim
DEBUG [lua] onSim2
DEBUG [lua] onPostSim
DEBUG [lua] onPostSim2
DEBUG [lua] Got my event
DEBUG [lua] onRender
DEBUG [lua] onRender2
DEBUG [lua] onPostRender
DEBUG [lua] onPostRender2
DEBUG [lua] onPreInput
DEBUG [lua] onPreInput2
DEBUG [lua] onInput
DEBUG [lua] onInput2
DEBUG [lua] onPostInput
DEBUG [lua] onPostInput2
```