### PR TITLE
Reformat imports, enforce formatting for PRs.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,7 @@
-name: Build Binaries
+name: CI
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
     paths-ignore:
     - '**/README.md'
     - '**/CONTRIBUTING.md'
@@ -15,15 +13,26 @@ on:
     - '**/.gitattributes'
     - '**/.editorconfig'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: write
 
 jobs:
+  run-linters:
+    name: Run linters
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install nightly
+        run: |
+          rustup update --no-self-update nightly
+          rustup component add --toolchain nightly rustfmt
+      - name: Format check
+        run: cargo +nightly fmt --check
+
   gen-build-version:
+    needs: run-linters
     name: Generate Build Version
     runs-on: ubuntu-latest
     outputs:
@@ -44,11 +53,16 @@ jobs:
           echo "SHA_SHORT=$CALCULATED_SHA" >> $GITHUB_ENV
       - name: Confirm git commit SHA output
         run: echo $SHA_SHORT
+      - name: Extract branch name
+        shell: bash
+        run: |
+          BRANCH_NAME=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          echo "BRANCH=${BRANCH_NAME/\//\\\/}" >> $GITHUB_ENV
       - name: Confirm nightly build name
         id: build_name
         run: |
-          echo $NEXT_VERSION-$SHA_SHORT
-          echo build=$NEXT_VERSION-$SHA_SHORT >> $GITHUB_OUTPUT
+          echo ${NEXT_VERSION}-${BRANCH}-${SHA_SHORT}
+          echo build="${NEXT_VERSION}-${BRANCH}-${SHA_SHORT}" >> $GITHUB_OUTPUT
 
   build-windows:
     needs: gen-build-version
@@ -146,60 +160,3 @@ jobs:
             ${{github.workspace}}/script/*
             ${{github.workspace}}/LICENSE
             ${{github.workspace}}/README.md
-
-  release:
-    name: New release
-    needs:
-      - gen-build-version
-      - build-windows
-      - build-macos
-      - build-linux
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-      - name: Inspect directory after downloading artifacts
-        run: ls -alFR
-      - name: Zip artifacts
-        run: for dir in $(ls); do cd $dir && zip ../$dir.zip ./* -r && cd ..; done
-      - name: echo repo
-        run: echo ${{github.repository}}
-      - name: Get latest release ID
-        uses: octokit/request-action@v2.x
-        id: get_latest_release
-        with:
-          route: GET /repos/${{github.repository}}/releases/tags/latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Delete latest release
-        uses: octokit/request-action@v2.x
-        with:
-          route: DELETE /repos/${{github.repository}}/releases/{release_id}
-          release_id: ${{ fromJson(steps.get_latest_release.outputs.data).id }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Delete 'latest' tag ref
-        uses: octokit/request-action@v2.x
-        with:
-          route: DELETE /repos/${{github.repository}}/git/refs/tags/latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Re-create 'latest' tag with the current SHA
-        uses: octokit/request-action@v2.x
-        with:
-          route: POST /repos/${{github.repository}}/git/refs
-          ref: refs/tags/latest
-          sha: ${{ github.sha }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create release
-        uses: softprops/action-gh-release@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          name: "Nightly ${{ needs.gen-build-version.outputs.build }}"
-          body: "Build log: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          tag_name: latest
-          draft: false
-          prerelease: true
-          files: ./*.zip

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -17,7 +17,15 @@ permissions:
   contents: write
 
 jobs:
+  run-linters:
+    name: Run linters
+    runs-on: ubuntu-latest
+    steps:
+    - name: Format check
+    - run: cargo fmt --check
+
   gen-build-version:
+    needs: run-linters
     name: Generate Build Version
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -24,6 +24,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Install nightly
+        run: |
+          rustup update --no-self-update nightly
+          rustup component add --toolchain nightly rustfmt
       - name: Format check
         run: cargo +nightly fmt --check
 

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -21,8 +21,11 @@ jobs:
     name: Run linters
     runs-on: ubuntu-latest
     steps:
-    - name: Format check
-    - run: cargo fmt --check
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Format check
+        run: cargo +nightly fmt --check
 
   gen-build-version:
     needs: run-linters

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,9 @@
-name: Build Binaries (Pull Request)
+name: Release
 
 on:
-  pull_request:
+  push:
+    branches:
+      - main
     paths-ignore:
     - '**/README.md'
     - '**/CONTRIBUTING.md'
@@ -13,26 +15,15 @@ on:
     - '**/.gitattributes'
     - '**/.editorconfig'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 
 jobs:
-  run-linters:
-    name: Run linters
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Install nightly
-        run: |
-          rustup update --no-self-update nightly
-          rustup component add --toolchain nightly rustfmt
-      - name: Format check
-        run: cargo +nightly fmt --check
-
   gen-build-version:
-    needs: run-linters
     name: Generate Build Version
     runs-on: ubuntu-latest
     outputs:
@@ -53,16 +44,11 @@ jobs:
           echo "SHA_SHORT=$CALCULATED_SHA" >> $GITHUB_ENV
       - name: Confirm git commit SHA output
         run: echo $SHA_SHORT
-      - name: Extract branch name
-        shell: bash
-        run: |
-          BRANCH_NAME=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          echo "BRANCH=${BRANCH_NAME/\//\\\/}" >> $GITHUB_ENV
       - name: Confirm nightly build name
         id: build_name
         run: |
-          echo ${NEXT_VERSION}-${BRANCH}-${SHA_SHORT}
-          echo build="${NEXT_VERSION}-${BRANCH}-${SHA_SHORT}" >> $GITHUB_OUTPUT
+          echo $NEXT_VERSION-$SHA_SHORT
+          echo build=$NEXT_VERSION-$SHA_SHORT >> $GITHUB_OUTPUT
 
   build-windows:
     needs: gen-build-version
@@ -160,3 +146,60 @@ jobs:
             ${{github.workspace}}/script/*
             ${{github.workspace}}/LICENSE
             ${{github.workspace}}/README.md
+
+  release:
+    name: New release
+    needs:
+      - gen-build-version
+      - build-windows
+      - build-macos
+      - build-linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+      - name: Inspect directory after downloading artifacts
+        run: ls -alFR
+      - name: Zip artifacts
+        run: for dir in $(ls); do cd $dir && zip ../$dir.zip ./* -r && cd ..; done
+      - name: echo repo
+        run: echo ${{github.repository}}
+      - name: Get latest release ID
+        uses: octokit/request-action@v2.x
+        id: get_latest_release
+        with:
+          route: GET /repos/${{github.repository}}/releases/tags/latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Delete latest release
+        uses: octokit/request-action@v2.x
+        with:
+          route: DELETE /repos/${{github.repository}}/releases/{release_id}
+          release_id: ${{ fromJson(steps.get_latest_release.outputs.data).id }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Delete 'latest' tag ref
+        uses: octokit/request-action@v2.x
+        with:
+          route: DELETE /repos/${{github.repository}}/git/refs/tags/latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Re-create 'latest' tag with the current SHA
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /repos/${{github.repository}}/git/refs
+          ref: refs/tags/latest
+          sha: ${{ github.sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: "Nightly ${{ needs.gen-build-version.outputs.build }}"
+          body: "Build log: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          tag_name: latest
+          draft: false
+          prerelease: true
+          files: ./*.zip

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,5 +1,0 @@
-reorder_imports = true
-
-# These only work with `cargo +nightly fmt`
-# imports_granularity = "Module"
-# group_imports = "StdExternalCrate"

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,5 @@
+reorder_imports = true
+
+# These only work with `cargo +nightly fmt`
+# imports_granularity = "Module"
+# group_imports = "StdExternalCrate"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,3 +135,7 @@ As we use the `cargo` ecosystem, if you're iterating on engine code, it might be
 This will essentially run `cargo build && ./target/debug/ltr` in one step. You can pass `--release` to `cargo run` to enable optimizations. If you'd like to launch with a specific script, you can pass it as an argument to `cargo run`:
 
 - `cargo run -- <script name without extension>`
+
+## Formatting
+
+Engine code uses `cargo +nightly fmt` to format its code. If you get a linting error in CI, you'll need to run this first to ensure your changes are formatted correctly. The script `./format.sh` is provided for convenience.

--- a/engine/bin/ltr/build.rs
+++ b/engine/bin/ltr/build.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::path::Path;
+
 use winres::WindowsResource;
 
 fn main() {

--- a/engine/bin/ltr/src/main.rs
+++ b/engine/bin/ltr/src/main.rs
@@ -1,5 +1,6 @@
-use clap::Parser;
 use std::ffi::CString;
+
+use clap::Parser;
 
 #[cfg(target_os = "windows")]
 #[no_mangle]

--- a/engine/lib/luajit-ffi-gen/src/args/arg.rs
+++ b/engine/lib/luajit-ffi-gen/src/args/arg.rs
@@ -1,8 +1,6 @@
 use proc_macro2::Ident;
-use syn::{
-    parse::{Parse, ParseStream},
-    Error, ExprLit, Result, Token,
-};
+use syn::parse::{Parse, ParseStream};
+use syn::{Error, ExprLit, Result, Token};
 
 /// Parse `key = value` pairs of the attribute arguments.
 pub struct Arg {

--- a/engine/lib/luajit-ffi-gen/src/enum_item/generate.rs
+++ b/engine/lib/luajit-ffi-gen/src/enum_item/generate.rs
@@ -1,9 +1,9 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
-use crate::{args::EnumAttrArgs, util::camel_to_snake_case};
-
 use super::EnumInfo;
+use crate::args::EnumAttrArgs;
+use crate::util::camel_to_snake_case;
 
 impl EnumInfo {
     /// Generate C API and Lua FFI.

--- a/engine/lib/luajit-ffi-gen/src/enum_item/lua_ffi.rs
+++ b/engine/lib/luajit-ffi-gen/src/enum_item/lua_ffi.rs
@@ -1,8 +1,8 @@
+use super::EnumInfo;
+use crate::args::EnumAttrArgs;
 use crate::ffi_generator::FfiGenerator;
 use crate::impl_item::TypeVariant;
-use crate::{args::EnumAttrArgs, IDENT};
-
-use super::EnumInfo;
+use crate::IDENT;
 
 impl EnumInfo {
     /// Generate Lua FFI file

--- a/engine/lib/luajit-ffi-gen/src/enum_item/parse.rs
+++ b/engine/lib/luajit-ffi-gen/src/enum_item/parse.rs
@@ -4,10 +4,9 @@ use syn::parse::Result;
 use syn::spanned::Spanned;
 use syn::{Attribute, Error, Expr, ExprLit, Fields, ItemEnum, Lit, Variant};
 
-use crate::util::parse_doc_attrs;
-
 use super::variants_info::VariantsInfo;
 use super::*;
+use crate::util::parse_doc_attrs;
 
 impl EnumInfo {
     pub fn parse(item: ItemEnum, attrs: &[Attribute]) -> Result<Self> {

--- a/engine/lib/luajit-ffi-gen/src/impl_item/generate.rs
+++ b/engine/lib/luajit-ffi-gen/src/impl_item/generate.rs
@@ -2,11 +2,10 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::Ident;
 
-use crate::args::ImplAttrArgs;
-
 use super::method_info::*;
 use super::type_info::*;
 use super::ImplInfo;
+use crate::args::ImplAttrArgs;
 
 impl ImplInfo {
     /// Generate C API and Lua FFI.

--- a/engine/lib/luajit-ffi-gen/src/impl_item/lua_ffi.rs
+++ b/engine/lib/luajit-ffi-gen/src/impl_item/lua_ffi.rs
@@ -1,6 +1,7 @@
-use crate::{args::ImplAttrArgs, ffi_generator::FfiGenerator, IDENT};
-
 use super::{ImplInfo, TypeInfo, TypeVariant};
+use crate::args::ImplAttrArgs;
+use crate::ffi_generator::FfiGenerator;
+use crate::IDENT;
 
 impl ImplInfo {
     /// Generate Lua FFI file

--- a/engine/lib/luajit-ffi-gen/src/impl_item/method_info.rs
+++ b/engine/lib/luajit-ffi-gen/src/impl_item/method_info.rs
@@ -1,6 +1,6 @@
-use crate::{args::BindArgs, util::snake_to_camel_case};
-
 use super::TypeInfo;
+use crate::args::BindArgs;
+use crate::util::snake_to_camel_case;
 
 /// `Impl` method information
 pub struct MethodInfo {

--- a/engine/lib/luajit-ffi-gen/src/impl_item/parse.rs
+++ b/engine/lib/luajit-ffi-gen/src/impl_item/parse.rs
@@ -3,12 +3,11 @@ use syn::parse::{Error, Parse, Result};
 use syn::spanned::Spanned;
 use syn::{Attribute, FnArg, ImplItem, ItemImpl, Pat, ReturnType, Type};
 
+use super::*;
 use crate::args::BindArgs;
 use crate::util::{
     get_meta_name, get_path_last_name, get_path_last_name_with_generics, parse_doc_attrs,
 };
-
-use super::*;
 
 impl ImplInfo {
     pub fn parse(mut item: ItemImpl, attrs: &[Attribute]) -> Result<Self> {

--- a/engine/lib/luajit-ffi-gen/src/lib.rs
+++ b/engine/lib/luajit-ffi-gen/src/lib.rs
@@ -5,13 +5,12 @@ mod impl_item;
 mod parse;
 mod util;
 
-use crate::args::EnumAttrArgs;
-use crate::args::ImplAttrArgs;
-use crate::parse::Item;
-
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse_macro_input;
+
+use crate::args::{EnumAttrArgs, ImplAttrArgs};
+use crate::parse::Item;
 
 pub(crate) const IDENT: &str = "    ";
 

--- a/engine/lib/luajit-ffi-gen/tests/test_impl.rs
+++ b/engine/lib/luajit-ffi-gen/tests/test_impl.rs
@@ -1,6 +1,5 @@
-use luajit_ffi_gen::luajit_ffi;
-
 use internal::ConvertIntoString;
+use luajit_ffi_gen::luajit_ffi;
 
 #[derive(Default, Clone)]
 pub struct Data {

--- a/engine/lib/phx/build.rs
+++ b/engine/lib/phx/build.rs
@@ -1,12 +1,10 @@
 #![allow(unused_imports, dead_code)]
-use gl_generator::{Api, Fallbacks, GlobalGenerator, Profile, Registry};
-
-use std::env;
-use std::fs;
 use std::fs::File;
 use std::io::Cursor;
-use std::path::Path;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::{env, fs};
+
+use gl_generator::{Api, Fallbacks, GlobalGenerator, Profile, Registry};
 
 fn main() {
     let phx_version = env::var("PHX_VERSION").unwrap_or_else(|_| "0.0.0".to_string());

--- a/engine/lib/phx/src/audio/audio.rs
+++ b/engine/lib/phx/src/audio/audio.rs
@@ -7,9 +7,8 @@ use kira::spatial::scene::{SpatialSceneHandle, SpatialSceneSettings};
 use kira::tween::{Easing, Tween};
 use kira::StartTime;
 
-use crate::math::*;
-
 use super::{Sound, SoundInstance};
+use crate::math::*;
 
 const DEFAULT_COMMAND_CAPACITY: usize = 1024;
 

--- a/engine/lib/phx/src/audio/sound.rs
+++ b/engine/lib/phx/src/audio/sound.rs
@@ -1,5 +1,4 @@
 use internal::ConvertIntoString;
-
 use kira::sound::static_sound::StaticSoundData;
 use kira::sound::{EndPosition, PlaybackPosition, Region};
 

--- a/engine/lib/phx/src/audio/sound_instance.rs
+++ b/engine/lib/phx/src/audio/sound_instance.rs
@@ -1,10 +1,12 @@
 use std::time::Duration;
 
-use crate::math::Position;
-use kira::sound::{static_sound::StaticSoundHandle, PlaybackState};
+use kira::sound::static_sound::StaticSoundHandle;
+use kira::sound::PlaybackState;
 use kira::spatial::emitter::EmitterHandle;
 use kira::tween::{Easing, Tween};
 use kira::StartTime;
+
+use crate::math::Position;
 
 struct EmitterInfo {
     emitter: EmitterHandle,

--- a/engine/lib/phx/src/engine/engine.rs
+++ b/engine/lib/phx/src/engine/engine.rs
@@ -2,13 +2,13 @@ use std::cell::RefCell;
 use std::path::PathBuf;
 
 use glam::*;
+use internal::ConvertIntoString;
 use mlua::{Function, Lua};
 use tracing::*;
 use winit::dpi::*;
 use winit::event_loop::*;
 
-use internal::ConvertIntoString;
-
+use super::MainLoop;
 use crate::common::*;
 use crate::event_bus::*;
 use crate::input::*;
@@ -17,8 +17,6 @@ use crate::rf::*;
 use crate::system::*;
 use crate::ui::hmgui::HmGui;
 use crate::window::*;
-
-use super::MainLoop;
 
 pub struct Engine {
     pub init_time: TimeStamp,

--- a/engine/lib/phx/src/event_bus/mod.rs
+++ b/engine/lib/phx/src/event_bus/mod.rs
@@ -1,15 +1,15 @@
-use std::collections::{hash_map::Entry, BinaryHeap, HashMap, VecDeque};
+use std::collections::hash_map::Entry;
+use std::collections::{BinaryHeap, HashMap, VecDeque};
 use std::sync::atomic::{AtomicU32, Ordering};
-
-use internal::ConvertIntoString;
-use strum::IntoEnumIterator;
-use tracing::{info, warn};
 
 use event::*;
 use event_data::*;
 use frame_stage::*;
 use frame_timer::*;
+use internal::ConvertIntoString;
 use message_request::*;
+use strum::IntoEnumIterator;
+use tracing::{info, warn};
 
 mod event;
 mod event_data;

--- a/engine/lib/phx/src/input/device.rs
+++ b/engine/lib/phx/src/input/device.rs
@@ -1,5 +1,5 @@
-use std::hash::Hasher;
-use std::{collections::hash_map::DefaultHasher, hash::Hash};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 
 use super::{InputDeviceId, InputDeviceType};
 

--- a/engine/lib/phx/src/input/mod.rs
+++ b/engine/lib/phx/src/input/mod.rs
@@ -19,10 +19,9 @@ pub use device_id::*;
 pub use device_type::*;
 pub use devices::*;
 pub use drag_and_drop::*;
+use gilrs::GamepadId;
 pub use system_event::*;
 pub use user_change::*;
-
-use gilrs::GamepadId;
 use winit::event::DeviceId;
 
 use crate::system::TimeStamp;

--- a/engine/lib/phx/src/logging.rs
+++ b/engine/lib/phx/src/logging.rs
@@ -1,10 +1,11 @@
 use std::io::Write;
 
 use regex::Regex;
-use tracing_appender::{non_blocking::WorkerGuard, rolling::RollingFileAppender};
-use tracing_subscriber::{prelude::*, EnvFilter};
-
 pub use tracing::{error, info, warn};
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_appender::rolling::RollingFileAppender;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::EnvFilter;
 
 /// Clean messages from coloring ASCII instructions before writing to the file.
 struct MessageCleaner {

--- a/engine/lib/phx/src/math/math.rs
+++ b/engine/lib/phx/src/math/math.rs
@@ -1,9 +1,8 @@
-use crate::error::Error;
-
 // Re-export glam types.
 pub use glam::{dvec2, dvec3, dvec4, DVec2, DVec3, DVec4};
-pub use glam::{ivec2, ivec3, ivec4, IVec2, IVec3, IVec4};
-pub use glam::{vec2, vec3, vec4, Vec2, Vec3, Vec4};
+pub use glam::{ivec2, ivec3, ivec4, vec2, vec3, vec4, IVec2, IVec3, IVec4, Vec2, Vec3, Vec4};
+
+use crate::error::Error;
 
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/engine/lib/phx/src/math/math.rs
+++ b/engine/lib/phx/src/math/math.rs
@@ -1,6 +1,8 @@
 // Re-export glam types.
-pub use glam::{dvec2, dvec3, dvec4, DVec2, DVec3, DVec4};
-pub use glam::{ivec2, ivec3, ivec4, vec2, vec3, vec4, IVec2, IVec3, IVec4, Vec2, Vec3, Vec4};
+pub use glam::{
+    dvec2, dvec3, dvec4, ivec2, ivec3, ivec4, vec2, vec3, vec4, DVec2, DVec3, DVec4, IVec2, IVec3,
+    IVec4, Vec2, Vec3, Vec4,
+};
 
 use crate::error::Error;
 

--- a/engine/lib/phx/src/math/matrix.rs
+++ b/engine/lib/phx/src/math/matrix.rs
@@ -1,8 +1,7 @@
+pub use glam::{Mat3, Mat4};
 use tracing::info;
 
 use crate::math::*;
-
-pub use glam::{Mat3, Mat4};
 
 // glam::Mat4 is a column-major matrix.
 pub type Matrix = Mat4;

--- a/engine/lib/phx/src/math/position.rs
+++ b/engine/lib/phx/src/math/position.rs
@@ -1,5 +1,6 @@
-use super::*;
 use core::ops::*;
+
+use super::*;
 
 /// Create a position.
 #[inline(always)]

--- a/engine/lib/phx/src/math/quat.rs
+++ b/engine/lib/phx/src/math/quat.rs
@@ -1,7 +1,7 @@
+pub use glam::Quat;
+
 use crate::error::Error;
 use crate::math::*;
-
-pub use glam::Quat;
 
 pub trait QuatExtensions {
     fn canonicalize(&self) -> Quat;

--- a/engine/lib/phx/src/physics/collision_shape.rs
+++ b/engine/lib/phx/src/physics/collision_shape.rs
@@ -1,8 +1,8 @@
+use rapier3d_f64::prelude::{self as rp, nalgebra as na, ColliderBuilder};
+
 use crate::math::{Box3, Vec3};
 use crate::physics::*;
 use crate::render::*;
-use rapier3d_f64::prelude::nalgebra as na;
-use rapier3d_f64::prelude::{self as rp, ColliderBuilder};
 
 pub type CollisionGroup = u32;
 pub type CollisionMask = u32;

--- a/engine/lib/phx/src/physics/physics.rs
+++ b/engine/lib/phx/src/physics/physics.rs
@@ -1,13 +1,15 @@
 #![allow(unused)]
 
+use std::ffi::{CStr, CString};
+
+use rapier3d_f64::parry::query::RayCast;
+use rapier3d_f64::prelude as rp;
+use rapier3d_f64::prelude::nalgebra as na;
+
 use crate::math::*;
 use crate::physics::*;
 use crate::render::*;
 use crate::rf::Rf;
-use rapier3d_f64::parry::query::RayCast;
-use rapier3d_f64::prelude as rp;
-use rapier3d_f64::prelude::nalgebra as na;
-use std::ffi::{CStr, CString};
 
 #[repr(C)]
 pub struct Collision {

--- a/engine/lib/phx/src/render/font.rs
+++ b/engine/lib/phx/src/render/font.rs
@@ -1,17 +1,16 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::ffi::CStr;
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 use std::ptr::addr_of_mut;
+
+use freetype_sys::*;
+use internal::*;
 
 use super::*;
 use crate::common::*;
 use crate::math::*;
 use crate::rf::Rf;
 use crate::system::{Profiler_Begin, Profiler_End, ResourceType, Resource_GetPath};
-
-use freetype_sys::*;
-use internal::*;
 
 /* TODO : Re-implement UTF-8 support */
 /* TODO : Atlas instead of individual textures. */

--- a/engine/lib/phx/src/render/shader.rs
+++ b/engine/lib/phx/src/render/shader.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
-use std::ffi::CStr;
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 
 use internal::*;
 

--- a/engine/lib/phx/src/render/shader_state.rs
+++ b/engine/lib/phx/src/render/shader_state.rs
@@ -1,6 +1,7 @@
+use internal::ConvertIntoString;
+
 use super::*;
 use crate::math::*;
-use internal::ConvertIntoString;
 
 pub struct ShaderState {
     shader: Shader,

--- a/engine/lib/phx/src/render/texcube.rs
+++ b/engine/lib/phx/src/render/texcube.rs
@@ -344,8 +344,12 @@ pub unsafe extern "C" fn TexCube_Generate(this: &mut TexCube, state: &mut Shader
         RenderTarget_BindTexCube(this, face.face);
         Draw_Clear(0.0f32, 0.0f32, 0.0f32, 1.0f32);
 
-        state.shader().set_float3("cubeLook", face.look.x, face.look.y, face.look.z);
-        state.shader().set_float3("cubeUp", face.up.x, face.up.y, face.up.z);
+        state
+            .shader()
+            .set_float3("cubeLook", face.look.x, face.look.y, face.look.z);
+        state
+            .shader()
+            .set_float3("cubeUp", face.up.x, face.up.y, face.up.z);
         state.shader().set_float("cubeSize", size_f);
 
         state.start();

--- a/engine/lib/phx/src/render/ui_renderer/image.rs
+++ b/engine/lib/phx/src/render/ui_renderer/image.rs
@@ -1,8 +1,7 @@
 use glam::Vec2;
 
-use crate::render::Tex2D;
-
 use super::UIRendererImageId;
+use crate::render::Tex2D;
 
 #[derive(Clone)]
 pub struct UIRendererImage {

--- a/engine/lib/phx/src/render/ui_renderer/mod.rs
+++ b/engine/lib/phx/src/render/ui_renderer/mod.rs
@@ -5,12 +5,13 @@ mod rect;
 mod renderer;
 mod text;
 
-use self::image::*;
 use layer::*;
 use panel::*;
 use rect::*;
 pub use renderer::*;
 use text::*;
+
+use self::image::*;
 
 macro_rules! def_id {
     ($name:ident) => {

--- a/engine/lib/phx/src/render/ui_renderer/panel.rs
+++ b/engine/lib/phx/src/render/ui_renderer/panel.rs
@@ -1,8 +1,7 @@
 use glam::Vec2;
 
-use crate::render::Color;
-
 use super::UIRendererPanelId;
+use crate::render::Color;
 
 #[derive(Clone)]
 pub struct UIRendererPanel {

--- a/engine/lib/phx/src/render/ui_renderer/rect.rs
+++ b/engine/lib/phx/src/render/ui_renderer/rect.rs
@@ -1,8 +1,7 @@
 use glam::Vec2;
 
-use crate::render::Color;
-
 use super::UIRendererRectId;
+use crate::render::Color;
 
 #[derive(Clone)]
 pub struct UIRendererRect {

--- a/engine/lib/phx/src/render/ui_renderer/text.rs
+++ b/engine/lib/phx/src/render/ui_renderer/text.rs
@@ -1,8 +1,7 @@
 use glam::Vec2;
 
-use crate::render::{Color, Font};
-
 use super::UIRendererTextId;
+use crate::render::{Color, Font};
 
 #[derive(Clone)]
 pub struct UIRendererText {

--- a/engine/lib/phx/src/system/bytes.rs
+++ b/engine/lib/phx/src/system/bytes.rs
@@ -1,12 +1,12 @@
 use std::ffi::CStr;
 use std::io::Write;
 
-use super::*;
-
 use flate2::write::{ZlibDecoder, ZlibEncoder};
 use flate2::Compression;
 use internal::*;
 use tracing::info;
+
+use super::*;
 
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/engine/lib/phx/src/system/hash_map.rs
+++ b/engine/lib/phx/src/system/hash_map.rs
@@ -1,7 +1,7 @@
-use super::*;
-
 use internal::*;
 use libc;
+
+use super::*;
 
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/engine/lib/phx/src/system/signal.rs
+++ b/engine/lib/phx/src/system/signal.rs
@@ -1,9 +1,9 @@
+use std::collections::HashMap;
+use std::ffi::CStr;
+
 use internal::static_string;
 
 use crate::logging::warn;
-
-use std::collections::HashMap;
-use std::ffi::CStr;
 
 pub type Signal = i32;
 pub type SignalHandler = extern "C" fn(Signal) -> ();

--- a/engine/lib/phx/src/system/time.rs
+++ b/engine/lib/phx/src/system/time.rs
@@ -1,6 +1,6 @@
-use chrono::{DateTime, Datelike, Local, TimeZone, Timelike, Utc};
-
 use std::time::{SystemTime, UNIX_EPOCH};
+
+use chrono::{DateTime, Datelike, Local, TimeZone, Timelike, Utc};
 
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/engine/lib/phx/src/ui/hmgui/container.rs
+++ b/engine/lib/phx/src/ui/hmgui/container.rs
@@ -2,10 +2,9 @@ use std::cell::RefMut;
 
 use glam::Vec2;
 
+use super::*;
 use crate::input::Input;
 use crate::rf::Rf;
-
-use super::*;
 
 /// Container element layout type.
 #[luajit_ffi_gen::luajit_ffi(name = "GuiLayoutType")]

--- a/engine/lib/phx/src/ui/hmgui/gui.rs
+++ b/engine/lib/phx/src/ui/hmgui/gui.rs
@@ -3,13 +3,12 @@ use std::collections::HashMap;
 use arboard::Clipboard;
 use glam::*;
 
+use super::*;
 use crate::common::*;
 use crate::input::*;
 use crate::render::*;
 use crate::rf::Rf;
 use crate::system::*;
-
-use super::*;
 
 pub struct HmGui {
     pub(super) renderer: UIRenderer,

--- a/engine/lib/phx/src/ui/hmgui/image.rs
+++ b/engine/lib/phx/src/ui/hmgui/image.rs
@@ -1,8 +1,7 @@
 use glam::Vec2;
 
-use crate::render::Tex2D;
-
 use super::HmGui;
+use crate::render::Tex2D;
 
 #[derive(Default, Clone, Copy, PartialEq)]
 pub enum HmGuiImageLayout {

--- a/engine/lib/phx/src/ui/hmgui/layer.rs
+++ b/engine/lib/phx/src/ui/hmgui/layer.rs
@@ -1,8 +1,8 @@
 use glam::Vec2;
 
-use crate::{rf::Rf, system::Hash_FNV64_Init};
-
 use super::{HmGuiWidget, WidgetItem};
+use crate::rf::Rf;
+use crate::system::Hash_FNV64_Init;
 
 pub const UNDEFINED_LAYER_INDEX: usize = 0xFFFFFFFF;
 

--- a/engine/lib/phx/src/ui/hmgui/mod.rs
+++ b/engine/lib/phx/src/ui/hmgui/mod.rs
@@ -9,18 +9,18 @@ mod text;
 mod text_line;
 mod widget;
 
-use internal::*;
-
-pub use self::image::*;
 pub use alignment::*;
 pub use container::*;
 use data::*;
 pub use focus_type::*;
 pub use gui::*;
+use internal::*;
 pub use layer::*;
 pub use text::*;
 pub use text_line::*;
 pub use widget::*;
+
+pub use self::image::*;
 
 const IDENT: &str = "  ";
 
@@ -33,9 +33,8 @@ mod tests {
 
     use glam::Vec2;
 
-    use crate::input::Input;
-
     use super::*;
+    use crate::input::Input;
 
     static mut RESOURCES_INITIALIZED: bool = false;
 

--- a/engine/lib/phx/src/ui/hmgui/text/text_context.rs
+++ b/engine/lib/phx/src/ui/hmgui/text/text_context.rs
@@ -1,4 +1,4 @@
-use std::sync::{Mutex, LazyLock};
+use std::sync::{LazyLock, Mutex};
 
 use parley::{FontContext, LayoutContext};
 use swash::scale::ScaleContext;

--- a/engine/lib/phx/src/ui/hmgui/text/text_cursor_rect.rs
+++ b/engine/lib/phx/src/ui/hmgui/text/text_cursor_rect.rs
@@ -3,9 +3,8 @@ use std::ops::Range;
 use glam::Vec2;
 use parley::layout::Cursor;
 
-use crate::render::Color;
-
 use super::TextLayout;
+use crate::render::Color;
 
 /// Rectangular area that represents cursor current position in text editing.
 #[derive(Debug, Clone, PartialEq)]

--- a/engine/lib/phx/src/ui/hmgui/text/text_data.rs
+++ b/engine/lib/phx/src/ui/hmgui/text/text_data.rs
@@ -1,20 +1,18 @@
 use glam::Vec2;
+use internal::ConvertIntoString;
 use parley::layout::{Alignment, GlyphRun};
 use parley::style::StyleProperty;
 use parley::Layout;
 use swash::scale::ScaleContext;
 use swash::FontRef;
 
-use internal::ConvertIntoString;
-
-use crate::input::{Button, Input};
-use crate::render::{
-    Color, DataFormat_Float, PixelFormat_RGBA, Tex2D, Tex2D_Create, Tex2D_SetData, TexFormat_RGBA8,
-};
-
 use super::text_render::render_glyph;
 use super::{
     TextAlignment, TextContext, TextCursorRect, TextSectionStyle, TextSelection, TextStyle,
+};
+use crate::input::{Button, Input};
+use crate::render::{
+    Color, DataFormat_Float, PixelFormat_RGBA, Tex2D, Tex2D_Create, Tex2D_SetData, TexFormat_RGBA8,
 };
 
 pub type TextLayout = Layout<Color>;

--- a/engine/lib/phx/src/ui/hmgui/text/text_render.rs
+++ b/engine/lib/phx/src/ui/hmgui/text/text_render.rs
@@ -1,5 +1,6 @@
 use parley::layout::Glyph;
-use swash::scale::{image::Content, Render, Scaler, Source, StrikeWith};
+use swash::scale::image::Content;
+use swash::scale::{Render, Scaler, Source, StrikeWith};
 use swash::zeno::{Format, Vector};
 
 use crate::render::Color;

--- a/engine/lib/phx/src/ui/hmgui/text/text_section_style.rs
+++ b/engine/lib/phx/src/ui/hmgui/text/text_section_style.rs
@@ -2,9 +2,8 @@ use std::ops::Range;
 
 use parley::context::RangedBuilder;
 
-use crate::render::Color;
-
 use super::TextStyle;
+use crate::render::Color;
 
 /// Style of text section.
 #[derive(Clone, PartialEq)]

--- a/engine/lib/phx/src/ui/hmgui/text/text_selection.rs
+++ b/engine/lib/phx/src/ui/hmgui/text/text_selection.rs
@@ -3,9 +3,8 @@ use std::ops::Range;
 use glam::Vec2;
 use parley::layout::Cursor;
 
-use crate::input::{Button, Input};
-
 use super::TextLayout;
+use crate::input::{Button, Input};
 
 const NEWLINE_SEPARATORS: &[char] = &['\n', '\r'];
 

--- a/engine/lib/phx/src/ui/hmgui/text/text_style.rs
+++ b/engine/lib/phx/src/ui/hmgui/text/text_style.rs
@@ -1,10 +1,9 @@
 use std::ops::Range;
 
 use indexmap::IndexMap;
+use internal::ConvertIntoString;
 use parley::context::RangedBuilder;
 use parley::style::{FontStack, FontStretch, FontStyle, FontWeight, StyleProperty};
-
-use internal::ConvertIntoString;
 
 use crate::render::Color;
 

--- a/engine/lib/phx/src/ui/hmgui/text/text_view.rs
+++ b/engine/lib/phx/src/ui/hmgui/text/text_view.rs
@@ -1,9 +1,8 @@
 use glam::Vec2;
 
+use super::{TextContext, TextData};
 use crate::input::Input;
 use crate::render::{Tex2D, Tex2D_Free};
-
-use super::{TextContext, TextData};
 
 /// Contains text data and rendered text texture.
 pub struct TextView {

--- a/engine/lib/phx/src/ui/hmgui/widget.rs
+++ b/engine/lib/phx/src/ui/hmgui/widget.rs
@@ -3,11 +3,9 @@ use std::borrow::BorrowMut;
 use glam::Vec2;
 use tracing::warn;
 
+use super::{Alignment, FocusType, HmGui, HmGuiContainer, HmGuiImage, HmGuiText, IDENT, TEXT_CTX};
 use crate::input::Input;
 use crate::render::Color;
-
-use super::{Alignment, FocusType, HmGui, HmGuiContainer, HmGuiImage, HmGuiText, IDENT, TEXT_CTX};
-
 use crate::rf::Rf;
 
 #[derive(Clone, PartialEq)]

--- a/engine/lib/phx/src/window/mod.rs
+++ b/engine/lib/phx/src/window/mod.rs
@@ -11,6 +11,7 @@ mod winit_window;
 
 pub use cursor::*;
 pub use glutin_render::*;
+use internal::ConvertIntoString;
 pub use monitor_selection::*;
 pub use present_mode::*;
 pub use window_mode::*;
@@ -19,8 +20,6 @@ pub use window_resize_constraints::*;
 pub use window_resolution::*;
 pub use winit_converters::*;
 pub use winit_window::*;
-
-use internal::ConvertIntoString;
 
 use crate::math::*;
 use crate::render::*;

--- a/engine/lib/phx/src/window/winit_converters.rs
+++ b/engine/lib/phx/src/window/winit_converters.rs
@@ -1,7 +1,7 @@
-use crate::input::{KeyboardButton, MouseControl};
 use winit::keyboard::KeyCode as WinitKeyCode;
 
 use super::{CursorIcon, WindowTheme};
+use crate::input::{KeyboardButton, MouseControl};
 
 pub fn convert_keycode(keycode: WinitKeyCode) -> KeyboardButton {
     match keycode {

--- a/engine/lib/phx/src/window/winit_window.rs
+++ b/engine/lib/phx/src/window/winit_window.rs
@@ -11,10 +11,8 @@ use glutin::surface::{GlSurface, Surface, SurfaceAttributes, WindowSurface};
 use glutin_winit::{DisplayBuilder, GlWindow};
 use raw_window_handle::HasWindowHandle;
 use tracing::{debug, error, info, warn};
-use winit::{
-    dpi::{LogicalSize, PhysicalPosition},
-    monitor::MonitorHandle,
-};
+use winit::dpi::{LogicalSize, PhysicalPosition};
+use winit::monitor::MonitorHandle;
 
 use super::{
     glutin_render, CursorGrabMode, PresentMode, Window, WindowMode, WindowPosition,

--- a/format.sh
+++ b/format.sh
@@ -1,0 +1,2 @@
+#/bin/sh
+cargo +nightly fmt

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+reorder_imports = true
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"


### PR DESCRIPTION
I've noticed a few times a PR gets merged, then a `cargo fmt` in another PR updates the formatting of previously merged PRs.

To prevent this, I've added an additional linting CI step that runs before anything else to check this before we run CI.

As part of this PR, I also introduced a `.rustfmt.toml` file. It includes these unstable features:

```
imports_granularity = "Module"
group_imports = "StdExternalCrate"
```

I've commented them out, to prevent warnings when running the stable `cargo fmt`, but I decided to run `cargo +nightly fmt` with these options enabled, which significantly tidied up our imports.