### PR TITLE
Add 'nil' alternative for param and return docs in meta

### DIFF
--- a/engine/lib/luajit-ffi-gen/src/impl_item/generate_lua.rs
+++ b/engine/lib/luajit-ffi-gen/src/impl_item/generate_lua.rs
@@ -90,9 +90,14 @@ impl ImplInfo {
                 // Add method signature documentation
                 method.params.iter().for_each(|param| {
                     ffi_gen.add_class_definition(format!(
-                        "---@param {} {}",
+                        "---@param {} {}{}",
                         param.as_ffi_name(),
-                        param.ty.as_lua_ffi_string(module_name)
+                        param.ty.as_lua_ffi_string(module_name),
+                        if param.ty.wrapper == TypeWrapper::Option {
+                            "|nil"
+                        } else {
+                            ""
+                        }
                     ));
 
                     // If this is a slice or array, we need to additionally generate a "size" parameter.
@@ -136,8 +141,13 @@ impl ImplInfo {
                         params.push("result".into());
                     } else {
                         ffi_gen.add_class_definition(format!(
-                            "---@return {}",
-                            ret.as_lua_ffi_string(module_name)
+                            "---@return {}{}",
+                            ret.as_lua_ffi_string(module_name),
+                            if ret.wrapper == TypeWrapper::Option {
+                                "|nil"
+                            } else {
+                                ""
+                            }
                         ));
                     }
                 }

--- a/engine/lib/phx/script/meta/Directory.lua
+++ b/engine/lib/phx/script/meta/Directory.lua
@@ -4,10 +4,10 @@
 Directory = {}
 
 ---@param path string
----@return Directory
+---@return Directory|nil
 function Directory.Open(path) end
 
----@return string
+---@return string|nil
 function Directory:getNext() end
 
 ---@param cwd string
@@ -18,12 +18,12 @@ function Directory.Change(cwd) end
 ---@return boolean
 function Directory.Create(path) end
 
----@return string
+---@return string|nil
 function Directory.GetCurrent() end
 
 ---@param org string
 ---@param app string
----@return string
+---@return string|nil
 function Directory.GetPrefPath(org, app) end
 
 ---@param path string

--- a/engine/lib/phx/script/meta/DragAndDropState.lua
+++ b/engine/lib/phx/script/meta/DragAndDropState.lua
@@ -3,10 +3,10 @@
 ---@class DragAndDropState
 DragAndDropState = {}
 
----@return string
+---@return string|nil
 function DragAndDropState:getDroppedFile() end
 
----@return string
+---@return string|nil
 function DragAndDropState:getHoveredFile() end
 
 ---@return boolean

--- a/engine/lib/phx/script/meta/EventBus.lua
+++ b/engine/lib/phx/script/meta/EventBus.lua
@@ -19,7 +19,7 @@ function EventBus:register(eventName, priority, frameStage, withFrameStageMessag
 function EventBus:unregister(eventName) end
 
 ---@param eventName string
----@param entityId integer
+---@param entityId integer|nil
 ---@return integer
 ---@overload fun(self: table, eventName: string, ctxTable: table|nil, callbackFunc: function): integer
 function EventBus:subscribe(eventName, entityId) end
@@ -29,11 +29,11 @@ function EventBus:unsubscribe(tunnelId) end
 
 ---@param eventName string
 ---@param entityId integer
----@param payload EventPayload
+---@param payload EventPayload|nil
 ---@overload fun(self: table, eventName: string, ctxTable: table|nil)
 function EventBus:send(eventName, entityId, payload) end
 
----@return EventData
+---@return EventData|nil
 function EventBus:getNextEvent() end
 
 function EventBus:printFrameStageMap() end

--- a/engine/lib/phx/script/meta/EventData.lua
+++ b/engine/lib/phx/script/meta/EventData.lua
@@ -12,6 +12,6 @@ function EventData:getFrameStage() end
 ---@return integer
 function EventData:getTunnelId() end
 
----@return EventPayload
+---@return EventPayload|nil
 function EventData:getPayload() end
 

--- a/engine/lib/phx/script/meta/EventPayload.lua
+++ b/engine/lib/phx/script/meta/EventPayload.lua
@@ -7,98 +7,98 @@ EventPayload = {}
 ---@return EventPayload
 function EventPayload.FromLua(value) end
 
----@return integer
+---@return integer|nil
 function EventPayload:asLua() end
 
 ---@param value boolean
 ---@return EventPayload
 function EventPayload.FromBool(value) end
 
----@return boolean
+---@return boolean|nil
 function EventPayload:asBool() end
 
 ---@param value integer
 ---@return EventPayload
 function EventPayload.FromI8(value) end
 
----@return integer
+---@return integer|nil
 function EventPayload:asI8() end
 
 ---@param value integer
 ---@return EventPayload
 function EventPayload.FromU8(value) end
 
----@return integer
+---@return integer|nil
 function EventPayload:asU8() end
 
 ---@param value integer
 ---@return EventPayload
 function EventPayload.FromI16(value) end
 
----@return integer
+---@return integer|nil
 function EventPayload:asI16() end
 
 ---@param value integer
 ---@return EventPayload
 function EventPayload.FromU16(value) end
 
----@return integer
+---@return integer|nil
 function EventPayload:asU16() end
 
 ---@param value integer
 ---@return EventPayload
 function EventPayload.FromI32(value) end
 
----@return integer
+---@return integer|nil
 function EventPayload:asI32() end
 
 ---@param value integer
 ---@return EventPayload
 function EventPayload.FromU32(value) end
 
----@return integer
+---@return integer|nil
 function EventPayload:asU32() end
 
 ---@param value integer
 ---@return EventPayload
 function EventPayload.FromI64(value) end
 
----@return integer
+---@return integer|nil
 function EventPayload:asI64() end
 
 ---@param value integer
 ---@return EventPayload
 function EventPayload.FromU64(value) end
 
----@return integer
+---@return integer|nil
 function EventPayload:asU64() end
 
 ---@param value number
 ---@return EventPayload
 function EventPayload.FromF32(value) end
 
----@return number
+---@return number|nil
 function EventPayload:asF32() end
 
 ---@param value number
 ---@return EventPayload
 function EventPayload.FromF64(value) end
 
----@return number
+---@return number|nil
 function EventPayload:asF64() end
 
 ---@param value string
 ---@return EventPayload
 function EventPayload.FromString(value) end
 
----@return string
+---@return string|nil
 function EventPayload:asString() end
 
 ---@param value EventPayloadTable
 ---@return EventPayload
 function EventPayload.FromTable(value) end
 
----@return EventPayloadTable
+---@return EventPayloadTable|nil
 function EventPayload:asTable() end
 
 ---@return EventPayloadType

--- a/engine/lib/phx/script/meta/EventPayloadTable.lua
+++ b/engine/lib/phx/script/meta/EventPayloadTable.lua
@@ -14,7 +14,7 @@ function EventPayloadTable:len() end
 function EventPayloadTable:contains(name) end
 
 ---@param name string
----@return EventPayload
+---@return EventPayload|nil
 function EventPayloadTable:get(name) end
 
 ---@param name string

--- a/engine/lib/phx/script/meta/GamepadState.lua
+++ b/engine/lib/phx/script/meta/GamepadState.lua
@@ -7,11 +7,11 @@ GamepadState = {}
 function GamepadState:gamepadsCount() end
 
 ---@param index integer
----@return GamepadId
+---@return GamepadId|nil
 function GamepadState:gamepadId(index) end
 
 ---@param gamepadId GamepadId
----@return string
+---@return string|nil
 function GamepadState:gamepadName(gamepadId) end
 
 ---@param axis GamepadAxis

--- a/engine/lib/phx/script/meta/Input.lua
+++ b/engine/lib/phx/script/meta/Input.lua
@@ -18,13 +18,13 @@ function Input:gamepad() end
 ---@return DragAndDropState
 function Input:dragAndDrop() end
 
----@return InputDevice
+---@return InputDevice|nil
 function Input:activeDevice() end
 
----@return InputDeviceType
+---@return InputDeviceType|nil
 function Input:activeDeviceType() end
 
----@return InputDeviceId
+---@return InputDeviceId|nil
 function Input:activeDeviceId() end
 
 ---@param visible boolean

--- a/engine/lib/phx/script/meta/RigidBody.lua
+++ b/engine/lib/phx/script/meta/RigidBody.lua
@@ -31,7 +31,7 @@ function RigidBody.CreateTrimeshFromMesh(mesh) end
 
 -- Return a reference to the parent rigid body, that we can guarantee
 -- has a lifetime as long as self.
----@return RigidBody
+---@return RigidBody|nil
 function RigidBody:getParentBody() end
 
 ---@param force Vec3f

--- a/engine/lib/phx/script/meta/TextStyle.lua
+++ b/engine/lib/phx/script/meta/TextStyle.lua
@@ -27,7 +27,7 @@ function TextStyle:setFontItalic(italic) end
 ---@param weight number
 function TextStyle:setFontWeight(weight) end
 
----@param locale string
+---@param locale string|nil
 function TextStyle:setLocale(locale) end
 
 -- Brush for rendering text.
@@ -47,7 +47,7 @@ function TextStyle:setUnderlineOffset(offset) end
 function TextStyle:setUnderlineSize(size) end
 
 -- Brush for rendering the underline decoration.
----@param color Color
+---@param color Color|nil
 function TextStyle:setUnderlineBrush(color) end
 
 -- Strikethrough decoration.
@@ -63,7 +63,7 @@ function TextStyle:setStrikethroughOffset(offset) end
 function TextStyle:setStrikethroughSize(size) end
 
 -- Brush for rendering the strikethrough decoration.
----@param color Color
+---@param color Color|nil
 function TextStyle:setStrikethroughBrush(color) end
 
 -- Line height multiplier.

--- a/engine/lib/phx/script/meta/Trigger.lua
+++ b/engine/lib/phx/script/meta/Trigger.lua
@@ -22,7 +22,7 @@ function Trigger:getContentsCount() end
 
 -- Will only include the parent object when a compound is within the trigger.
 ---@param i integer
----@return RigidBody
+---@return RigidBody|nil
 function Trigger:getContents(i) end
 
 ---@param mask integer
@@ -40,6 +40,6 @@ function Trigger:getPos(result) end
 ---@param result Position [out]
 function Trigger:getPosLocal(result) end
 
----@return RigidBody
+---@return RigidBody|nil
 function Trigger:getParent() end
 

--- a/engine/lib/phx/script/meta/Window.lua
+++ b/engine/lib/phx/script/meta/Window.lua
@@ -144,13 +144,13 @@ function Window:scaleFactor() end
 -- Returns `None` if the cursor is outside the window area.
 -- 
 -- See [`WindowResolution`] for an explanation about logical/physical sizes.
----@return Vec2f
+---@return Vec2f|nil
 function Window:cursorPosition() end
 
 -- Set the cursor position in this window in logical pixels.
 -- 
 -- See [`WindowResolution`] for an explanation about logical/physical sizes.
----@param position Vec2f
+---@param position Vec2f|nil
 function Window:setCursorPosition(position) end
 
 -- The cursor position in this window in physical pixels.
@@ -158,12 +158,12 @@ function Window:setCursorPosition(position) end
 -- Returns `None` if the cursor is outside the window area.
 -- 
 -- See [`WindowResolution`] for an explanation about logical/physical sizes.
----@return Vec2f
+---@return Vec2f|nil
 function Window:physicalCursorPosition() end
 
 -- Set the cursor position in this window in physical pixels.
 -- 
 -- See [`WindowResolution`] for an explanation about logical/physical sizes.
----@param position Vec2d
+---@param position Vec2d|nil
 function Window:setPhysicalCursorPosition(position) end
 


### PR DESCRIPTION
Add `nil` alternative to the Optional types in in the generated meta files.