### PR TITLE
Update Ubuntu build from 20.04 to 22.04.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,8 +128,8 @@ jobs:
 
   build-linux:
     needs: gen-build-version
-    name: Build Linux (Ubuntu 20.04)
-    runs-on: ubuntu-20.04
+    name: Build Linux (Ubuntu 22.04)
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Update packages

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,8 +114,8 @@ jobs:
 
   build-linux:
     needs: gen-build-version
-    name: Build Linux (Ubuntu 20.04)
-    runs-on: ubuntu-20.04
+    name: Build Linux (Ubuntu 22.04)
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Update packages


### PR DESCRIPTION
GitHub is removing support for Ubuntu 20.04 in Actions, so we need to move to another version. I picked 22.04 as the earliest supported LTS version (so pre-built binaries can run on as many versions of Ubuntu as possible)