### PR TITLE
Licensing Clarification for Limit Theory Redux

### DIFF
--- a/.github/workflows/update_license_years.yaml
+++ b/.github/workflows/update_license_years.yaml
@@ -1,21 +1,19 @@
 name: Update License Years
-
 on:
   schedule:
     # Run at 00:00 on January 1
-    - cron: '0 0 1 1 *'
+    - cron: "0 0 1 1 *"
   workflow_dispatch:
     # Manual trigger
     inputs:
       org_name:
-        description: 'Organization name to use in MIT license files (leave empty to use existing)'
+        description: "Organization name to use in MIT license files (leave empty to use existing)"
         required: false
-        default: ''
-
+        default: ""
 jobs:
   update-license-years:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -23,7 +21,7 @@ jobs:
         run: |
           # Get current year
           CURRENT_YEAR=$(date +"%Y")
-          
+
           # Get organization name from input or use repository owner
           if [ -n "${{ github.event.inputs.org_name }}" ]; then
             ORG_NAME="${{ github.event.inputs.org_name }}"
@@ -31,7 +29,7 @@ jobs:
             # Extract organization name from the repository
             ORG_NAME="${GITHUB_REPOSITORY_OWNER}"
           fi
-          
+
           # Update MIT License
           if [ -f LICENSE-MIT ]; then
             # Check for different copyright line formats and update accordingly
@@ -47,12 +45,20 @@ jobs:
               fi
             fi
           fi
-          
+
           # Update Apache License - ONLY update the year
           if [ -f LICENSE-APACHE-2.0 ]; then
             if grep -q "Copyright " LICENSE-APACHE-2.0; then
               # Only update the year
               sed -i -E "s/(Copyright )[0-9]{4}(-[0-9]{4})?( .+)/\1$CURRENT_YEAR\3/" LICENSE-APACHE-2.0
+            fi
+          fi
+
+          # Update NOTICE file - ONLY update the year
+          if [ -f NOTICE ]; then
+            if grep -q "Copyright [0-9]\{4\} Limit Theory Redux Contributors" NOTICE; then
+              # Only update the year
+              sed -i -E "s/(Copyright )[0-9]{4}( Limit Theory Redux Contributors)/\1$CURRENT_YEAR\2/" NOTICE
             fi
           fi
       - name: Check for changes
@@ -75,8 +81,8 @@ jobs:
           title: "Update license year to ${{ env.CURRENT_YEAR }}"
           body: |
             Automated update of license years for the new year.
-            
-            This PR was automatically created by the GitHub Actions workflow.
+
+            This PR was automatically created by a GitHub Actions workflow.
           branch: license-year-update
           base: main
           delete-branch: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ By contributing to Limit Theory Redux, you agree to the following licensing stru
 
 - **Original Limit Theory Content**: All content derived from Josh Parnell's original Limit Theory project remains under [The Unlicense](./UNLICENSE-ORIGINAL.txt), effectively placing it in the public domain.
 
-- **New Contributions**: All new content and substantial modifications are dual-licensed under the [Apache License 2.0](./LICENSE-APACHE-2.0) and [MIT License](./LICENSE-MIT). You may choose either license at your option.
+- **New Contributions**: New content and substantial modifications are generally dual-licensed under the [Apache License 2.0](./LICENSE-APACHE-2.0) and [MIT License](./LICENSE-MIT). Refer to [NOTICE](./NOTICE) for exceptions to this rule.
 
 - **Mixed Content**: When modifying existing Unlicensed content from the original project, those specific portions remain under The Unlicense.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ It´s highly recommended you document what you are doing in code. For more gener
 
 # Getting Started
 
-In this file we´ll go over the whole process of getting started & the the workflow of Limit Theory Redux development.
+In this file we´ll go over the whole process of getting started & the workflow of Limit Theory Redux development.
 
 ## Prerequisites
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,31 +1,47 @@
 # Contributions
+
 We discuss all features, fixes etc. to be contributed on Discord.
 
+## Licensing Information
+
+By contributing to Limit Theory Redux, you agree to the following licensing structure:
+
+- **Original Limit Theory Content**: All content derived from Josh Parnell's original Limit Theory project remains under [The Unlicense](./UNLICENSE-ORIGINAL.txt), effectively placing it in the public domain.
+
+- **New Contributions**: All new content and substantial modifications are dual-licensed under the [Apache License 2.0](./LICENSE-APACHE-2.0) and [MIT License](./LICENSE-MIT). You may choose either license at your option.
+
+- **Mixed Content**: When modifying existing Unlicensed content from the original project, those specific portions remain under The Unlicense.
+
+For more detailed information about our licensing approach, please see the [NOTICE](./NOTICE) file.
+
 ## Discussing Gamedesign
+
 Discussions regarding game design are held in the ltheory-crafting channel:
 
 **Open on:**
 \
 \
 <a href="https://discord.com/channels/695088786702336000/1021252323663691826" style="display: block;">
-  <img style="height: 36px; display: block;" src="https://assets-global.website-files.com/6257adef93867e50d84d30e2/636e0b5061df29d55a92d945_full_logo_blurple_RGB.svg"/>
+<img style="height: 36px; display: block;" src="https://assets-global.website-files.com/6257adef93867e50d84d30e2/636e0b5061df29d55a92d945_full_logo_blurple_RGB.svg"/>
 </a>
 
-
 ## Discussing Gamesystems
+
 Discussions regarding game systems / programming are held in the programming-discussion channel:
 
 **Open on:**
 \
 \
 <a href="https://discord.com/channels/695088786702336000/1021816893629272174" style="display: block;">
-  <img style="height: 36px; display: block;" src="https://assets-global.website-files.com/6257adef93867e50d84d30e2/636e0b5061df29d55a92d945_full_logo_blurple_RGB.svg"/>
+<img style="height: 36px; display: block;" src="https://assets-global.website-files.com/6257adef93867e50d84d30e2/636e0b5061df29d55a92d945_full_logo_blurple_RGB.svg"/>
 </a>
 
 ## Documentation
+
 It´s highly recommended you document what you are doing in code. For more generalized documentation & design we use a seperately hosted [Wiki.js Instance](https://wiki.ltredux.org). For wiki editoral access contact [@IllustrisJack](https://github.com/IllustrisJack) directly or a maintainer. A backup repository of the wiki exists [here](https://github.com/Limit-Theory-Redux/wiki).
 
 # Getting Started
+
 In this file we´ll go over the whole process of getting started & the the workflow of Limit Theory Redux development.
 
 ## Prerequisites
@@ -35,6 +51,7 @@ To build Limit Theory, you'll need a few standard developer tools. All of them a
 ### Windows
 
 To work on any of the Lua scripts, the following tools are required:
+
 - Git: https://git-scm.com/downloads
 
 You may want to install a GUI for Git, such as GitHub for Desktop: https://desktop.github.com/
@@ -42,6 +59,7 @@ You may want to install a GUI for Git, such as GitHub for Desktop: https://deskt
 #### Optional dependencies
 
 Optionally, if you would like to made changes to the libphx engine, you will also need:
+
 - Visual Studio Community: https://visualstudio.microsoft.com/vs/
 - LLVM: https://releases.llvm.org/download.html (download the latest Windows installer by going to the GitHub releases page, and downloading LLVM-xx.x.x-win64.exe)
 - Rust: https://www.rust-lang.org/tools/install (use rustup-init.exe, then type 1 and press Enter in the terminal window)
@@ -93,7 +111,7 @@ Next, we will need to get the engine ready to run Lua applications. There are tw
 ### Option 1: Using precompiled binaries
 
 1. Download the latest binary release by going to the `latest` release on GitHub, and downloading the right `dev-binaries` package for your platform: https://github.com/Limit-Theory-Redux/ltheory/releases/tag/latest
-   * Windows users should download `dev-binaries-windows.zip`, we recommend other users to skip to [Compiling libphx manually](#option-2-compiling-libphx-manually).
+   - Windows users should download `dev-binaries-windows.zip`, we recommend other users to skip to [Compiling libphx manually](#option-2-compiling-libphx-manually).
 2. Navigate to the directory of the checked-out repository (e.g. `~/Desktop/ltheory` if you cloned to the desktop).
 3. Create a new folder named `bin` if it does not exist already.
 4. Extract the contents of the zip file downloaded in step 1 into `bin`. The `bin` directory should now contain a number of libraries and executable files, including `ltr`.

--- a/NOTICE
+++ b/NOTICE
@@ -20,6 +20,12 @@ This repository primarily uses an origin-based licensing approach for all files.
 
 In cases of ambiguity or particularly important content, we may add explicit license information to provide additional clarity.
 
+## Previous Contributions
+
+Code contributed to this project before the establishment of the dual Apache 2.0/MIT licensing remains under the copyright of the original contributors and under the original license terms that were in effect at the time of contribution.
+
+No attempt is made by this NOTICE to change or modify the licensing terms of these previous contributions without explicit consent from the copyright holders.
+
 ## Original Project Acknowledgment
 
 This project is a community continuation of Limit Theory, originally developed by Josh Parnell. The original content was released into the public domain under The Unlicense.

--- a/NOTICE
+++ b/NOTICE
@@ -1,24 +1,37 @@
 # NOTICE
 
-## Licensing Information
+# License Information for Limit-Theory-Redux
 
-This repository (Limit-Theory-Redux) contains content with mixed licensing based on its origin:
+## License Overview
 
-1. **Original Content from Limit Theory**
-   - All content (code, assets, documentation, etc.) directly derived from or substantially similar to Josh Parnell's original Limit Theory project remains under The Unlicense and is effectively in the public domain.
-   
-2. **New Contributions and Substantial Modifications**
-   - All new content, substantial modifications, and new creative additions to the Limit Theory Redux project are dual-licensed under the Apache License 2.0 and MIT License.
+This repository contains content with mixed licensing based on its origin:
 
-## License Identification
+### 1. Original Content from Limit Theory
+- **All content** (code, assets, documentation, etc.) directly derived from or substantially similar to Josh Parnell's original Limit Theory project remains under **The Unlicense** and is effectively in the public domain.
+
+### 2. New Contributions and Substantial Modifications
+- **All new content**, substantial modifications, and new creative additions to the Limit Theory Redux project are generally **dual-licensed** under the **Apache License 2.0** and **MIT License**.
+- **Exceptions**: Content that is marked with a specific licensing header or license file located in the file's directory as described in the License Identification section below (e.g., music contributed by artists using a Creative Commons License).
+
+## License Identification Method
 
 This repository primarily uses an origin-based licensing approach for all files. However:
 
 - Where explicit clarity is needed, individual files may contain license headers or notices specifying their exact license
 - Some key files or particularly mixed files may be explicitly marked with appropriate headers
-- In the absence of explicit file notices, the origin of the content determines its license as described above
+- License files located in a file's directory may specify the license for all content in that directory/or specific files in a directory
+- In the absence of explicit file notices or directory license files, the origin of the content determines its license as described above
 
-In cases of ambiguity or particularly important content, we may add explicit license information to provide additional clarity.
+In cases of ambiguity or for particularly important content, we may add explicit license information to provide additional clarity.
+
+## Determining License for Specific Files
+
+When working with files in this repository:
+
+1. Check for explicit license headers within the file
+2. Check for license files in the file's directory that may apply to all content in that directory/or specific files in a directory
+3. If neither exists, determine if the content originates from the original Limit Theory (Unlicense) or is a new contribution (Apache 2.0/MIT)
+4. For questions about specific file licensing, please open an issue in the repository
 
 ## Previous Contributions
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,35 @@
+# NOTICE
+
+## Licensing Information
+
+This repository (Limit-Theory-Redux) contains content with mixed licensing based on its origin:
+
+1. **Original Content from Limit Theory**
+   - All content (code, assets, documentation, etc.) directly derived from or substantially similar to Josh Parnell's original Limit Theory project remains under The Unlicense and is effectively in the public domain.
+   
+2. **New Contributions and Substantial Modifications**
+   - All new content, substantial modifications, and new creative additions to the Limit Theory Redux project are dual-licensed under the Apache License 2.0 and MIT License.
+
+## License Identification
+
+This repository primarily uses an origin-based licensing approach for all files. However:
+
+- Where explicit clarity is needed, individual files may contain license headers or notices specifying their exact license
+- Some key files or particularly mixed files may be explicitly marked with appropriate headers
+- In the absence of explicit file notices, the origin of the content determines its license as described above
+
+In cases of ambiguity or particularly important content, we may add explicit license information to provide additional clarity.
+
+## Original Project Acknowledgment
+
+This project is a community continuation of Limit Theory, originally developed by Josh Parnell. The original content was released into the public domain under The Unlicense.
+
+## License Selection for Dual-Licensed Content
+
+For the dual-licensed portions (new contributions and substantial modifications), you may choose either the Apache License 2.0 or MIT License at your option.
+
+## Copyright Notice
+
+Copyright 2025 Limit Theory Redux Contributors
+
+This copyright notice applies only to new content and significant transformations, not to portions directly derived from the original Unlicensed content.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@ This repository continues the game and engine code from the second generation of
 
 [Documentation](doc/README.md).
 
-## Contributing to Limit Theory Redux
-See [CONTRIBUTING.md](CONTRIBUTING.md) for more information.
-
 ## Screenshots
 
 ![LTR Screenshot](./res/images/Readme_01.png)
@@ -18,3 +15,41 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for more information.
 ![LTR Screenshot 2](./res/images/Readme_02.png)
 
 ![LTR Screenshot 3](./res/images/Readme_03.png)
+
+## Contributing to Limit Theory Redux
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for more information.
+
+## Licensing
+
+Limit Theory Redux contains content under two different licenses based on origin:
+
+### Original Limit Theory Content
+
+All content derived from Josh Parnell's original Limit Theory project (including code, assets, models, textures, sounds, documentation, etc.) remains under [The Unlicense](./UNLICENSE-ORIGINAL.txt), effectively placing it in the public domain. This means this portion of the project can be used for any purpose without restriction.
+
+### New Contributions
+
+All new content and substantial modifications created specifically for Limit Theory Redux are dual-licensed under:
+
+- [Apache License 2.0](./LICENSE-APACHE-2.0)
+- [MIT License](./LICENSE-MIT)
+
+You may choose either license at your option.
+
+### License Identification
+
+While we generally use an origin-based approach to licensing (original content under Unlicense, new content under Apache 2.0/MIT), some files may have explicit license notices:
+
+- Files with explicit notices follow the license specified in their notice
+- Files without explicit notices follow the origin-based licensing rules
+- For particularly complex or important files, we may add explicit license information for clarity
+
+### Contributing
+
+By contributing to this project, you agree that your contributions follow this same licensing structure:
+
+- Modifications to original Limit Theory content remain under The Unlicense
+- New content and substantial modifications are dual-licensed under Apache 2.0/MIT
+
+For more detailed information, please see the [NOTICE](./NOTICE) file.

--- a/README.md
+++ b/README.md
@@ -29,27 +29,23 @@ Limit Theory Redux contains content under two different licenses based on origin
 All content derived from Josh Parnell's original Limit Theory project (including code, assets, models, textures, sounds, documentation, etc.) remains under [The Unlicense](./UNLICENSE-ORIGINAL.txt), effectively placing it in the public domain. This means this portion of the project can be used for any purpose without restriction.
 
 ### New Contributions
-
-All new content and substantial modifications created specifically for Limit Theory Redux are dual-licensed under:
-
+All new content and substantial modifications created specifically for Limit Theory Redux are generally dual-licensed under:
 - [Apache License 2.0](./LICENSE-APACHE-2.0)
 - [MIT License](./LICENSE-MIT)
 
 You may choose either license at your option.
 
 ### License Identification
-
 While we generally use an origin-based approach to licensing (original content under Unlicense, new content under Apache 2.0/MIT), some files may have explicit license notices:
-
-- Files with explicit notices follow the license specified in their notice
-- Files without explicit notices follow the origin-based licensing rules
+- Files with explicit license headers follow the license specified in their header
+- License files located in a directory may specify the license for all content in that directory
+- Files without explicit headers or directory license files follow the origin-based licensing rules
 - For particularly complex or important files, we may add explicit license information for clarity
 
 ### Contributing
-
 By contributing to this project, you agree that your contributions follow this same licensing structure:
-
 - Modifications to original Limit Theory content remain under The Unlicense
-- New content and substantial modifications are dual-licensed under Apache 2.0/MIT
+- New content and substantial modifications are generally dual-licensed under Apache 2.0/MIT
+- Exceptions may be made for specific types of content (e.g., music, artwork) with appropriate license headers or license files
 
-For more detailed information, please see the [NOTICE](./NOTICE) file.
+For more detailed information about our licensing approach, please see the NOTICE file.

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ You may choose either license at your option.
 
 ### License Identification
 While we generally use an origin-based approach to licensing (original content under Unlicense, new content under Apache 2.0/MIT), some files may have explicit license notices:
-- Files with explicit license headers follow the license specified in their header
-- License files located in a directory may specify the license for all content in that directory
-- Files without explicit headers or directory license files follow the origin-based licensing rules
-- For particularly complex or important files, we may add explicit license information for clarity
+- Where explicit clarity is needed, individual files may contain license headers or notices specifying their exact license
+- Some key files or particularly mixed files may be explicitly marked with appropriate headers
+- License files located in a file's directory may specify the license for all content in that directory/or specific files in a directory
+- In the absence of explicit file notices or directory license files, the origin of the content determines its license as described above
 
 ### Contributing
 By contributing to this project, you agree that your contributions follow this same licensing structure:

--- a/UNLICENSE-ORIGINAL.txt
+++ b/UNLICENSE-ORIGINAL.txt
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>


### PR DESCRIPTION
This PR establishes clear documentation about our existing licensing approach for the Limit Theory Redux project, providing transparency without changing any actual license terms. (This is important for legal continuity)

## Changes:

- Added NOTICE file detailing our origin-based licensing approach
- Updated README with licensing information
- Added licensing section to CONTRIBUTING.md

## Benefits:

- Clarifies that original Limit Theory content remains under The Unlicense
- Documents the dual Apache 2.0/MIT licensing for new contributions
- Creates a descriptive framework that explains our mixed codebase
- Ensures contributors understand licensing expectations
- Reduces potential legal ambiguity while maintaining practicality